### PR TITLE
Fix huge security issue, disabling bstats doesn't work

### DIFF
--- a/src/main/java/catserver/server/Metrics.java
+++ b/src/main/java/catserver/server/Metrics.java
@@ -110,7 +110,7 @@ public class Metrics {
         logSentData = config.getBoolean("logSentData", false);
         logResponseStatusText = config.getBoolean("logResponseStatusText", false);
 
-        if (true || enabled) {
+        if (enabled) {
             startSubmitting();
         }
     }


### PR DESCRIPTION
This fixes a big security issue, where disabling bstats wouldn't work, exposing data the server admin doesn't want to expose.