### PR TITLE
Fix datapack load.

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1386,6 +1386,7 @@ public class ForgeHooks
 
     public static boolean loadAdvancements(Map<ResourceLocation, Advancement.Builder> map)
     {
+        CraftingHelper.init();
         boolean errored = false;
         setActiveModContainer(null);
         Loader.instance().getActiveModList().forEach(ForgeHooks::loadFactories);


### PR DESCRIPTION
**修复数据包加载。
Fix datapack load.**

在进入数据包加载阶段前清除哈希地图，这原本可能导致 _重复配方_ 系列异常在 [_net/minecraftforge/common/crafting/CraftingHelper_](https://github.com/Luohuayu/CatServer/blob/2bce5d5f1d9aa069f7ec4d8e1cae2c3e273f6e12/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java#L100-L117)。
Clear hashmap before entering datapack load phase, which originally could cause _duplicate recipe_ series exception at [_net/minecraftforge/common/crafting/CraftingHelper_](https://github.com/Luohuayu/CatServer/blob/2bce5d5f1d9aa069f7ec4d8e1cae2c3e273f6e12/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java#L100-L117).

例如，模组 [disenchanter](https://github.com/Impelon/Disenchanter) 会在世界加载阶段引起 _重复配方条件工厂_ 的异常，因为它的数据包中在配方和进度方面有相同的条件键值。
E.g., the mod [disenchanter](https://github.com/Impelon/Disenchanter) will cause _duplicate recipe condition factory_ exception during world load phase because its datapack has the same condition keyvalue in recipes and advancements.
