### PR TITLE
Fix ServerChatEvent not being called (#653)

### DIFF
--- a/patches/minecraft/net/minecraft/network/play/ServerPlayNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/ServerPlayNetHandler.java.patch
@@ -1007,7 +1007,7 @@
        }
     }
  
-@@ -1076,51 +_,255 @@
+@@ -1076,51 +_,264 @@
           PacketThreadUtil.func_218796_a(p_147354_1_, this, this.field_147369_b.func_71121_q());
           this.func_244548_c(s);
        } else {
@@ -1028,6 +1028,24 @@
           for(int i = 0; i < p_244548_1_.length(); ++i) {
              if (!SharedConstants.func_71566_a(p_244548_1_.charAt(i))) {
 -               this.func_194028_b(new TranslationTextComponent("multiplayer.disconnect.illegal_characters"));
+-               return;
+-            }
+-         }
+-
+-         if (p_244548_1_.startsWith("/")) {
+-            this.func_147361_d(p_244548_1_);
+-         } else {
+-            ITextComponent itextcomponent = new TranslationTextComponent("chat.type.text", this.field_147369_b.func_145748_c_(), p_244548_1_);
+-            this.field_147367_d.func_184103_al().func_232641_a_(itextcomponent, ChatType.CHAT, this.field_147369_b.func_110124_au());
+-         }
+-
+-         this.field_147374_l += 20;
+-         if (this.field_147374_l > 200 && !this.field_147367_d.func_184103_al().func_152596_g(this.field_147369_b.func_146103_bH())) {
+-            this.func_194028_b(new TranslationTextComponent("disconnect.spam"));
+-         }
+-
+-      }
+-   }
 +               // CraftBukkit start - threadsafety
 +               if (!p_244548_1_.startsWith("/")) {
 +                  Waitable waitable = new Waitable() {
@@ -1051,12 +1069,10 @@
 +                  this.func_194028_b(new TranslationTextComponent("multiplayer.disconnect.illegal_characters"));
 +               }
 +               // CraftBukkit end
-                return;
-             }
-          }
- 
--         if (p_244548_1_.startsWith("/")) {
--            this.func_147361_d(p_244548_1_);
++               return;
++            }
++         }
++
 +         // CraftBukkit start
 +         if (isSync) {
 +            try {
@@ -1080,21 +1096,14 @@
 +         } else if (true) {
 +            this.chat(p_244548_1_, true);
 +            // CraftBukkit end
-          } else {
--            ITextComponent itextcomponent = new TranslationTextComponent("chat.type.text", this.field_147369_b.func_145748_c_(), p_244548_1_);
-+            ITextComponent itextcomponent = new TranslationTextComponent("chat.type.text", this.field_147369_b.func_145748_c_(), net.minecraftforge.common.ForgeHooks.newChatWithLinks(p_244548_1_));
++         } else {
++            /** Moved to {@link this#chat}
++            ITextComponent itextcomponent = new TranslationTextComponent("chat.type.text", this.player.getDisplayName(), net.minecraftforge.common.ForgeHooks.newChatWithLinks(p_244548_1_));
 +            itextcomponent = net.minecraftforge.common.ForgeHooks.onServerChatEvent(this, p_244548_1_, itextcomponent);
 +            if (itextcomponent == null) return;
-             this.field_147367_d.func_184103_al().func_232641_a_(itextcomponent, ChatType.CHAT, this.field_147369_b.func_110124_au());
-          }
--
--         this.field_147374_l += 20;
--         if (this.field_147374_l > 200 && !this.field_147367_d.func_184103_al().func_152596_g(this.field_147369_b.func_146103_bH())) {
--            this.func_194028_b(new TranslationTextComponent("disconnect.spam"));
--         }
--
--      }
--   }
++            this.server.getPlayerList().broadcastMessage(itextcomponent, ChatType.CHAT, this.player.getUUID());
++            */
++         }
 +         // CraftBukkit start - replaced with thread safe throttle
 +         // this.chatThrottle += 20;
 +         if (chatSpamField.addAndGet(this, 20) > 200 && !this.field_147367_d.func_184103_al().func_152596_g(this.field_147369_b.getProfile())) {
@@ -1134,6 +1143,13 @@
 +      } else if (this.field_147369_b.func_147096_v() == ChatVisibility.SYSTEM) {
 +         // Do nothing, this is coming from a plugin
 +      } else {
++         // CatServer start - Fire the forge event first, and replace the message sent to bukkit, removing the <player>
++         ITextComponent itextcomponent = new TranslationTextComponent("chat.type.text", this.field_147369_b.func_145748_c_(), net.minecraftforge.common.ForgeHooks.newChatWithLinks(s));
++         itextcomponent = net.minecraftforge.common.ForgeHooks.onServerChatEvent(this, s, itextcomponent);
++         if (itextcomponent == null) return;
++         s = itextcomponent.getString().substring(3 + this.field_147369_b.func_145748_c_().getString().length());
++         // CatServer end
++
 +         Player player = this.getPlayer();
 +         AsyncPlayerChatEvent event = new AsyncPlayerChatEvent(async, player, s, new LazyPlayerSet(field_147367_d));
 +         this.craftServer.getPluginManager().callEvent(event);


### PR DESCRIPTION
This PR fixes the issue when `ServerChatEvent` is not getting called. This also closes #653.

### Cause
The event was not called as it was in the unreachable code segment:

```java
// The "else if" branch is always executed, that's why the "else" branch is unreachable

} else if (true) {
  this.chat(p_244548_1_, true);
  // CraftBukkit end
} else {
  ITextComponent itextcomponent = new TranslationTextComponent("chat.type.text", this.field_147369_b.func_145748_c_(), p_244548_1_);
  ITextComponent itextcomponent = new TranslationTextComponent("chat.type.text", this.field_147369_b.func_145748_c_(), net.minecraftforge.common.ForgeHooks.newChatWithLinks(p_244548_1_));
  itextcomponent = net.minecraftforge.common.ForgeHooks.onServerChatEvent(this, p_244548_1_, itextcomponent);
  if (itextcomponent == null) return;
  this.field_147367_d.func_184103_al().func_232641_a_(itextcomponent, ChatType.CHAT, this.field_147369_b.func_110124_au());
}
```

### Solution
In order to fix this issue, the whole event execution was transferred to the `ServerPlayNetHandler#chat` function:

```patch
+   // CatServer start - Fire the forge event first, and replace the message sent to bukkit, removing the <player>
+   ITextComponent itextcomponent = new TranslationTextComponent("chat.type.text", this.field_147369_b.func_145748_c_(), net.minecraftforge.common.ForgeHooks.newChatWithLinks(s));
+   itextcomponent = net.minecraftforge.common.ForgeHooks.onServerChatEvent(this, s, itextcomponent);
+   if (itextcomponent == null) return;
+   s = itextcomponent.getString().substring(3 + this.field_147369_b.func_145748_c_().getString().length());
+   // CatServer end
```

### Similar approaches
The similar approach may be found [here](https://github.com/MohistMC/Mohist/blob/edca9329fd803ae4753842d5a9a611a42f42ab75/patches/minecraft/net/minecraft/network/play/ServerPlayNetHandler.java.patch#L1235-L1240).