### PR TITLE
Fix mixin injection exception of BiggerStacks

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -82,7 +82,7 @@
     private CompoundNBT field_77990_d;
     private boolean field_190928_g;
     private Entity field_234693_k_;
-@@ -109,33 +_,61 @@
+@@ -109,35 +_,70 @@
        p_i231596_3_.ifPresent(this::func_77982_d);
     }
  
@@ -119,8 +119,13 @@
        this.field_190928_g = this.func_190926_b();
     }
  
-+   // CraftBukkit start - break into own method
++   // CatServer start - try fix biggerstacks mixin injection exception
 +   private void load(CompoundNBT compound) {
++      this.loadNbt(compound);
++   }
++
++   // CraftBukkit start - break into own method
++   private CompoundNBT loadNbt(CompoundNBT compound) {
 +      this.capNBT = compound.func_74764_b("ForgeCaps") ? compound.func_74775_l("ForgeCaps") : null;
 +      Item rawItem =
 +      this.field_151002_e = Registry.field_212630_s.func_82594_a(new ResourceLocation(compound.func_74779_i("id")));
@@ -137,6 +142,7 @@
 +      if (this.func_77973_b().func_77645_m()) {
 +         this.func_196085_b(this.func_77952_i());
 +      }
++      return compound;
 +   }
 +
     private ItemStack(CompoundNBT p_i47263_1_) {
@@ -152,11 +158,14 @@
 -      }
 -
 +      super(ItemStack.class, true);
-+      this.load(p_i47263_1_);
-+      // CraftBukkit stop
++      CompoundNBT nbt = this.loadNbt(p_i47263_1_);
++      this.field_77994_a = nbt.func_74771_c("Count");
        this.func_190923_F();
     }
++   // CatServer end
  
+    public static ItemStack func_199557_a(CompoundNBT p_199557_0_) {
+       try {
 @@ -167,10 +_,19 @@
     }
  


### PR DESCRIPTION
This comes from our problem, because we broke the ItemStack constructor. Now, he works normally!