### PR TITLE
fix bukkit EntityDamageEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch
@@ -556,7 +556,7 @@
           float f1 = 0.0F;
           if (p_70097_2_ > 0.0F && this.func_184583_d(p_70097_1_)) {
              this.func_184590_k(p_70097_2_);
-@@ -955,22 +_,48 @@
+@@ -955,22 +_,40 @@
  
           this.field_70721_aZ = 1.5F;
           boolean flag1 = true;
@@ -569,24 +569,16 @@
  
 -            this.func_70665_d(p_70097_1_, p_70097_2_ - this.field_110153_bc);
 +            // CraftBukkit start
-+            if (this instanceof PlayerEntity) {
-+               this.func_70665_d(p_70097_1_, p_70097_2_ - this.field_110153_bc);
-+            } else {
-+               if (!this.damageEntity0(p_70097_1_, p_70097_2_ - this.field_110153_bc)) {
++            if (!this.damageEntity0(p_70097_1_, p_70097_2_ - this.field_110153_bc)) {
 +                  return false;
-+               }
 +            }
 +            // CraftBukkit end
              this.field_110153_bc = p_70097_2_;
              flag1 = false;
           } else {
 +            // CraftBukkit start
-+            if (this instanceof PlayerEntity) {
-+               this.func_70665_d(p_70097_1_, p_70097_2_);
-+            } else {
-+               if (!this.damageEntity0(p_70097_1_, p_70097_2_)) {
-+                  return false;
-+               }
++            if (!this.damageEntity0(p_70097_1_, p_70097_2_)) {
++               return false;
 +            }
 +            // CraftBukkit end
              this.field_110153_bc = p_70097_2_;

--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -380,7 +380,7 @@
              });
              if (this.field_184627_bm.func_190926_b()) {
                 if (hand == Hand.MAIN_HAND) {
-@@ -836,37 +_,68 @@
+@@ -836,37 +_,20 @@
                 } else {
                    this.func_184201_a(EquipmentSlotType.OFFHAND, ItemStack.field_190927_a);
                 }
@@ -394,68 +394,33 @@
     }
  
     protected void func_70665_d(DamageSource p_70665_1_, float p_70665_2_) {
-       if (!this.func_180431_b(p_70665_1_)) {
-+         p_70665_2_ = net.minecraftforge.common.ForgeHooks.onLivingHurt(this, p_70665_1_, p_70665_2_);
-+         if (p_70665_2_ <= 0) return;
-          p_70665_2_ = this.func_70655_b(p_70665_1_, p_70665_2_);
-          p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
-          float f2 = Math.max(p_70665_2_ - this.func_110139_bj(), 0.0F);
-          this.func_110149_m(this.func_110139_bj() - (p_70665_2_ - f2));
-+         f2 = net.minecraftforge.common.ForgeHooks.onLivingDamage(this, p_70665_1_, f2);
-          float f = p_70665_2_ - f2;
-          if (f > 0.0F && f < 3.4028235E37F) {
-             this.func_195067_a(Stats.field_212738_J, Math.round(f * 10.0F));
-          }
+-      if (!this.func_180431_b(p_70665_1_)) {
+-         p_70665_2_ = this.func_70655_b(p_70665_1_, p_70665_2_);
+-         p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
+-         float f2 = Math.max(p_70665_2_ - this.func_110139_bj(), 0.0F);
+-         this.func_110149_m(this.func_110139_bj() - (p_70665_2_ - f2));
+-         float f = p_70665_2_ - f2;
+-         if (f > 0.0F && f < 3.4028235E37F) {
+-            this.func_195067_a(Stats.field_212738_J, Math.round(f * 10.0F));
+-         }
 -
-          if (f2 != 0.0F) {
-             this.func_71020_j(p_70665_1_.func_76345_d());
-             float f1 = this.func_110143_aJ();
+-         if (f2 != 0.0F) {
+-            this.func_71020_j(p_70665_1_.func_76345_d());
+-            float f1 = this.func_110143_aJ();
 -            this.func_70606_j(this.func_110143_aJ() - f2);
-             this.func_110142_aN().func_94547_a(p_70665_1_, f1, f2);
+-            this.func_110142_aN().func_94547_a(p_70665_1_, f1, f2);
 -            if (f2 < 3.4028235E37F) {
 -               this.func_195067_a(Stats.field_188112_z, Math.round(f2 * 10.0F));
 -            }
 -
 -         }
 -      }
-+            this.func_70606_j(f1 - f2); // Forge: moved to fix MC-121048
-+            if (f2 < 3.4028235E37F) {
-+               this.func_195067_a(Stats.field_188112_z, Math.round(f2 * 10.0F));
-+            }
-+         }
-+      }
++      this.damageEntity0(p_70665_1_, p_70665_2_);
 +   }
 +
 +   @Override
-+   protected boolean damageEntity0(DamageSource damageSrc, float damageAmount) { // void -> boolean
-+      if (true) {
-+         return super.damageEntity0(damageSrc, damageAmount);
-+      }
-+      if (!this.func_180431_b(damageSrc)) {
-+         damageAmount = net.minecraftforge.common.ForgeHooks.onLivingHurt(this, damageSrc, damageAmount);
-+         if (damageAmount <= 0) return false;
-+         damageAmount = this.func_70655_b(damageSrc, damageAmount);
-+         damageAmount = this.func_70672_c(damageSrc, damageAmount);
-+         float f2 = Math.max(damageAmount - this.func_110139_bj(), 0.0F);
-+         this.func_110149_m(this.func_110139_bj() - (damageAmount - f2));
-+         f2 = net.minecraftforge.common.ForgeHooks.onLivingDamage(this, damageSrc, f2);
-+         float f = damageAmount - f2;
-+         if (f > 0.0F && f < 3.4028235E37F) {
-+            this.func_195067_a(Stats.field_212738_J, Math.round(f * 10.0F));
-+         }
-+
-+         if (f2 != 0.0F) {
-+            this.func_71020_j(damageSrc.func_76345_d());
-+            float f1 = this.func_110143_aJ();
-+            this.func_110142_aN().func_94547_a(damageSrc, f1, f2);
-+            this.func_70606_j(f1 - f2); // Forge: moved to fix MC-121048
-+            if (f2 < 3.4028235E37F) {
-+               this.func_195067_a(Stats.field_188112_z, Math.round(f2 * 10.0F));
-+            }
-+
-+         }
-+      }
-+      return false;
++   protected boolean damageEntity0(DamageSource damageSource, float damageAmount) {
++      return super.damageEntity0(damageSource, damageAmount);
     }
  
     protected boolean func_230296_cM_() {


### PR DESCRIPTION
Changes the damage receiving method, adds a return value. Removes redundant checks for instanceof PlayerEntity.
This fixes the work of events (especially EntityDamageEvent events for bukkit). Without it, such a plugin as WorldGuard does not work correctly (the pvp and invincible flags are ignored).

Cleaned up the code.