### PR TITLE
[1.16.5] Update Minecraft Wiki links to new domain

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -243,7 +243,7 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
 
     public void missingSoundMapping(RegistryEvent.MissingMappings<SoundEvent> event)
     {
-        //Removed in 1.15, see https://minecraft.gamepedia.com/Parrot#History
+        //Removed in 1.15, see https://minecraft.wiki/w/Parrot#History
         List<String> removedSounds = Arrays.asList("entity.parrot.imitate.panda", "entity.parrot.imitate.zombie_pigman", "entity.parrot.imitate.enderman", "entity.parrot.imitate.polar_bear", "entity.parrot.imitate.wolf");
         for (RegistryEvent.MissingMappings.Mapping<SoundEvent> mapping : event.getAllMappings())
         {

--- a/src/main/java/org/bukkit/GameRule.java
+++ b/src/main/java/org/bukkit/GameRule.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
  * GameRules dictate certain behavior within Minecraft itself
  * <br>
  * For more information please visit the
- * <a href="https://minecraft.gamepedia.com/Commands/gamerule">Minecraft
+ * <a href="https://minecraft.wiki/w/Commands/gamerule">Minecraft
  * Wiki</a>
  *
  * @param <T> type of rule (Boolean or Integer)

--- a/src/main/java/org/bukkit/HeightMap.java
+++ b/src/main/java/org/bukkit/HeightMap.java
@@ -3,7 +3,7 @@ package org.bukkit;
 /**
  * Further information regarding heightmaps.
  *
- * @see <a href="https://minecraft.gamepedia.com/Chunk_format">Gamepedia Chunk
+ * @see <a href="https://minecraft.wiki/w/Chunk_format">Minecraft Wiki Chunk
  * Format</a>
  */
 public enum HeightMap {

--- a/src/main/java/org/bukkit/UnsafeValues.java
+++ b/src/main/java/org/bukkit/UnsafeValues.java
@@ -44,7 +44,7 @@ public interface UnsafeValues {
      * layout.
      * <br>
      * It is currently a JSON object, as described by the Minecraft Wiki:
-     * http://minecraft.gamepedia.com/Advancements
+     * http://minecraft.wiki/w/Advancements
      * <br>
      * Loaded advancements will be stored and persisted across server restarts
      * and reloads.

--- a/src/main/java/org/bukkit/WorldCreator.java
+++ b/src/main/java/org/bukkit/WorldCreator.java
@@ -238,7 +238,7 @@ public class WorldCreator {
      * is as follows:
      * <code>{"structures": {"structures": {"village": {"salt": 8015723, "spacing": 32, "separation": 8}}}, "layers": [{"block": "stone", "height": 1}, {"block": "grass", "height": 1}], "biome":"plains"}</code>
      *
-     * @see <a href="https://minecraft.gamepedia.com/Custom_dimension">Custom
+     * @see <a href="https://minecraft.wiki/w/Custom_dimension">Custom
      * dimension</a> (scroll to "When the generator ID type is
      * <code>minecraft:flat</code>)"
      * @param generatorSettings The settings that should be used by the

--- a/src/main/java/org/bukkit/block/Structure.java
+++ b/src/main/java/org/bukkit/block/Structure.java
@@ -223,7 +223,7 @@ public interface Structure extends TileState {
     /**
      * Only applicable while in {@link UsageMode#DATA}. Metadata are specific
      * functions that can be applied to the structure location. Consult the
-     * <a href="https://minecraft.gamepedia.com/Structure_Block#Data">Minecraft
+     * <a href="https://minecraft.wiki/w/Structure_Block#Data">Minecraft
      * wiki</a> for more information.
      *
      * @param metadata the function to perform on the selected location
@@ -233,7 +233,7 @@ public interface Structure extends TileState {
     /**
      * Get the metadata function this structure block will perform when
      * activated. Consult the
-     * <a href="https://minecraft.gamepedia.com/Structure_Block#Data">Minecraft
+     * <a href="https://minecraft.wiki/w/Structure_Block#Data">Minecraft
      * Wiki</a> for more information.
      *
      * @return the function that will be performed when this block is activated

--- a/src/main/java/org/bukkit/block/structure/UsageMode.java
+++ b/src/main/java/org/bukkit/block/structure/UsageMode.java
@@ -23,7 +23,7 @@ public enum UsageMode {
      * Used to run specific custom functions, which can only be used for certain
      * Structures. The structure block is removed after this function completes.
      * The data tags (functions) can be found on the
-     * <a href="http://minecraft.gamepedia.com/Structure_Block#Data">wiki</a>.
+     * <a href="http://minecraft.wiki/w/Structure_Block#Data">wiki</a>.
      */
     DATA;
 }

--- a/src/main/java/org/bukkit/entity/TropicalFish.java
+++ b/src/main/java/org/bukkit/entity/TropicalFish.java
@@ -55,7 +55,7 @@ public interface TropicalFish extends Fish {
 
     /**
      * Enumeration of all different fish patterns. Refer to the
-     * <a href="https://minecraft.gamepedia.com/Fish_(mob)">Minecraft Wiki</a>
+     * <a href="https://minecraft.wiki/w/Fish_(mob)">Minecraft Wiki</a>
      * for pictures.
      */
     public static enum Pattern {

--- a/src/main/java/org/bukkit/loot/LootTable.java
+++ b/src/main/java/org/bukkit/loot/LootTable.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
  * naturally generated containers, what items should be dropped when killing a
  * mob, or what items can be fished.
  *
- * See the <a href="https://minecraft.gamepedia.com/Loot_table">
+ * See the <a href="https://minecraft.wiki/w/Loot_table">
  * Minecraft Wiki</a> for more information.
  */
 public interface LootTable extends Keyed {

--- a/src/main/java/org/bukkit/loot/LootTables.java
+++ b/src/main/java/org/bukkit/loot/LootTables.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
  * This list is not guaranteed to be accurate in future versions.
  *
  * See the
- * <a href="https://minecraft.gamepedia.com/Loot_table#List_of_loot_tables">
+ * <a href="https://minecraft.wiki/w/Loot_table#List_of_loot_tables">
  * Minecraft Wiki</a> for more information on loot tables.
  */
 public enum LootTables implements Keyed {


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.