### PR TITLE
修正机械动力蓝图加农炮加载蓝图失败的问题

### DIFF
--- a/src/main/java/org/spigotmc/ActivationRange.java
+++ b/src/main/java/org/spigotmc/ActivationRange.java
@@ -46,6 +46,7 @@ public class ActivationRange {
     }
 
     public static boolean initializeEntityActivationState(Entity entity, SpigotWorldConfig config) {
+        if (config == null) return false;
         if ((entity.activationType == ActivationType.MISC && config.miscActivationRange == 0)
                 || (entity.activationType == ActivationType.RAIDER && config.raiderActivationRange == 0)
                 || (entity.activationType == ActivationType.ANIMAL && config.animalActivationRange == 0)


### PR DESCRIPTION
## 原问题：

```java
16.12 23:49:34 [Server] INFO at java.lang.Thread.run(Thread.java:833) [?:?]
16.12 23:49:34 [Server] INFO at net.minecraft.server.MinecraftServer.m_177918_(MinecraftServer.java:344) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:984) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:1144) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.server.dedicated.DedicatedServer.m_5703_(DedicatedServer.java:397) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:1229) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:449) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.world.level.Level.m_46463_(Level.java:734) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.world.level.chunk.LevelChunk$RebindableTickingBlockEntityWrapper.m_142224_(LevelChunk.java:855) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.world.level.chunk.LevelChunk$BoundTickingBlockEntity.m_142224_(LevelChunk.java:757) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at com.simibubi.create.foundation.blockEntity.SmartBlockEntityTicker.m_155252_(SmartBlockEntityTicker.java:15) ~[create-1.18.2-0.5.1.f.jar%2377!/:0.5.1.f]
16.12 23:49:34 [Server] INFO at com.simibubi.create.content.schematics.cannon.SchematicannonBlockEntity.tick(SchematicannonBlockEntity.java:278) ~[create-1.18.2-0.5.1.f.jar%2377!/:0.5.1.f]
16.12 23:49:34 [Server] INFO at com.simibubi.create.content.schematics.cannon.SchematicannonBlockEntity.tickPaperPrinter(SchematicannonBlockEntity.java:684) ~[create-1.18.2-0.5.1.f.jar%2377!/:0.5.1.f]
16.12 23:49:34 [Server] INFO at com.simibubi.create.content.schematics.cannon.SchematicannonBlockEntity.initializePrinter(SchematicannonBlockEntity.java:450) ~[create-1.18.2-0.5.1.f.jar%2377!/:0.5.1.f]
16.12 23:49:34 [Server] INFO at com.simibubi.create.content.schematics.SchematicPrinter.loadSchematic(SchematicPrinter.java:101) ~[create-1.18.2-0.5.1.f.jar%2377!/:0.5.1.f]
16.12 23:49:34 [Server] INFO at net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.m_74536_(StructureTemplate.java:338) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.addEntitiesToWorld(StructureTemplate.java:408) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.processEntityInfos(StructureTemplate.java:397) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at com.simibubi.create.content.schematics.SchematicProcessor.processEntity(SchematicProcessor.java:50) ~[create-1.18.2-0.5.1.f.jar%2377!/:0.5.1.f]
16.12 23:49:34 [Server] INFO at java.util.Optional.flatMap(Optional.java:289) ~[?:?]
16.12 23:49:34 [Server] INFO at com.simibubi.create.content.schematics.SchematicProcessor.lambda$processEntity$1(SchematicProcessor.java:52) ~[create-1.18.2-0.5.1.f.jar%2377!/:0.5.1.f]
16.12 23:49:34 [Server] INFO at net.minecraft.world.entity.EntityType.m_20615_(EntityType.java:467) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.world.entity.item.ItemEntity.<init>(ItemEntity.java:56) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at net.minecraft.world.entity.Entity.<init>(Entity.java:328) ~[server-1.18.2-20220404.173914-srg.jar%23127!/:?]
16.12 23:49:34 [Server] INFO at org.spigotmc.ActivationRange.initializeEntityActivationState(ActivationRange.java:49) ~[forge-1.18.2-40.2.14-universal.jar%23132!/:?]
16.12 23:49:34 [Server] INFO java.lang.NullPointerException: Cannot read field "miscActivationRange" because "config" is null
16.12 23:49:34 [Server] Server thread/ERROR Failed to load Schematic for Printing
```

## 故障截图：
![686T2M7 O}GS$OQMYO%_%FN](https://github.com/Luohuayu/CatServer/assets/36336351/b756aa83-fdb5-47f6-bafa-3f7879d003c4)

## 问题原因：

spigot entity 的初始化时， initializeEntityActivationState 存在 level 非空，但 spigot config 不存在的情况（如在 create 模组蓝图加载时）
猜测是机械动力 com.simibubi.create.content.schematics.SchematicChunkSource 在加载蓝图时创建的 DummyLevel 实例导致的。不同于 net.minecraft.server.level.ServerLevel 实例，后者在构造时会初始化 this.spigotConfig，而 DummyLevel 不会

## 修正方式：

在 config = null 时 initializeEntityActivationState 默认返回 false（构造模组自定义的Level实例及其中的entity时，让spigot不干预）避免因 NPE 导致蓝图加农炮失效

## 测试结果：

蓝图加农炮正常加载蓝图

![image](https://github.com/Luohuayu/CatServer/assets/36336351/8e922661-d410-48e0-b1d6-64f4e64fb1a5)
