### PR TITLE
Bukkit 兼容 Forge 传递携带 Level 子类实例作为入参的桶放置事件

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/animal/Cow.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Cow.java.patch
@@ -14,7 +14,7 @@
        ItemStack itemstack = p_28298_.m_21120_(p_28299_);
        if (itemstack.m_150930_(Items.f_42446_) && !this.m_6162_()) {
 +         // CraftBukkit start - Got milk?
-+         org.bukkit.event.player.PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent((ServerLevel) p_28298_.f_19853_, p_28298_, this.m_142538_(), this.m_142538_(), null, itemstack, Items.f_42455_);
++         org.bukkit.event.player.PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent(p_28298_.f_19853_, p_28298_, this.m_142538_(), this.m_142538_(), null, itemstack, Items.f_42455_);
 +         if (event.isCancelled()) {
 +            return InteractionResult.PASS;
 +         }

--- a/patches/minecraft/net/minecraft/world/entity/animal/goat/Goat.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/goat/Goat.java.patch
@@ -14,7 +14,7 @@
        ItemStack itemstack = p_149379_.m_21120_(p_149380_);
        if (itemstack.m_150930_(Items.f_42446_) && !this.m_6162_()) {
 +         // CraftBukkit start - Got milk?
-+         org.bukkit.event.player.PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent((ServerLevel) p_149379_.f_19853_, p_149379_, this.m_142538_(), this.m_142538_(), null, itemstack, Items.f_42455_);
++         org.bukkit.event.player.PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent(p_149379_.f_19853_, p_149379_, this.m_142538_(), this.m_142538_(), null, itemstack, Items.f_42455_);
 +         if (event.isCancelled()) {
 +            return InteractionResult.PASS;
 +         }

--- a/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
@@ -90,7 +90,7 @@
                    this.m_142131_(p_40704_, p_40703_, itemstack, blockpos2);
                    if (p_40704_ instanceof ServerPlayer) {
                       CriteriaTriggers.f_10591_.m_59469_((ServerPlayer)p_40704_, blockpos2, itemstack);
-@@ -98,7 +_,32 @@
+@@ -98,7 +_,35 @@
     public void m_142131_(@Nullable Player p_150711_, Level p_150712_, ItemStack p_150713_, BlockPos p_150714_) {
     }
  
@@ -98,18 +98,21 @@
 +      return emptyContents(p_150716_, p_150717_, p_150718_, p_150719_, null, direction, clicked, itemstack);
 +   }
 +
++   private Direction bukkit_event$direction = null;
++   private BlockPos bukkit_event$clicked = null;
++   private ItemStack bukkit_event$itemstack = null;
 +   private boolean emptyContents(Player p_150716_, Level p_150717_, BlockPos p_150718_, @Nullable BlockHitResult p_150719_, @Nullable ItemStack container, Direction direction, BlockPos clicked, ItemStack itemstack) {
 +      // CatServer start
-+      catserver.server.CatServerCaptures.getCatServerCaptures().captureDirection(direction);
-+      catserver.server.CatServerCaptures.getCatServerCaptures().captureBlockPos(clicked);
-+      catserver.server.CatServerCaptures.getCatServerCaptures().captureItemStack(itemstack);
++      bukkit_event$direction = direction;
++      bukkit_event$clicked = clicked;
++      bukkit_event$itemstack = itemstack;
 +      try {
 +         return this.emptyContents(p_150716_, p_150717_, p_150718_, p_150719_, container);
 +      } finally {
 +         // CatServer - Make sure reset
-+         catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureBlockPos();
-+         catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureDirection();
-+         catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureItemStack();
++         bukkit_event$direction = null;
++         bukkit_event$clicked = null;
++         bukkit_event$itemstack = null;
 +      }
 +      // CatServer end
 +   }
@@ -129,11 +132,11 @@
           boolean flag1 = blockstate.m_60795_() || flag || block instanceof LiquidBlockContainer && ((LiquidBlockContainer)block).m_6044_(p_150717_, p_150718_, blockstate, this.f_40687_);
 +         var containedFluidStack = java.util.Optional.ofNullable(container).flatMap(net.minecraftforge.fluids.FluidUtil::getFluidContained);
 +         // CraftBukkit start
-+         var clicked = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureBlockPos();
-+         var enumdirection = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureDirection();
-+         var itemstack = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureItemStack();
-+         if (flag1 && p_150716_ != null) {
-+            PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent(p_150717_, p_150716_, p_150718_, clicked == null ? BlockPos.f_121853_ : clicked, enumdirection == null ? enumdirection = Direction.UP : enumdirection, itemstack == null ? ItemStack.f_41583_ : itemstack);
++         var clicked = bukkit_event$clicked == null ? BlockPos.f_121853_ : bukkit_event$clicked;
++         var enumdirection = bukkit_event$direction == null ? Direction.UP : bukkit_event$direction;
++         var itemstack = bukkit_event$itemstack == null ? ItemStack.f_41583_ : bukkit_event$itemstack;
++         if (flag1 && p_150716_ != null && catserver.server.utils.WorldCheck.isServerWorld(p_150717_)) {
++            PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent(p_150717_, p_150716_, p_150718_, clicked, enumdirection, itemstack);
 +            if (event.isCancelled()) {
 +               ((ServerPlayer) p_150716_).f_8906_.m_141995_(new ClientboundBlockUpdatePacket(p_150717_, p_150718_)); // SPIGOT-4238: needed when looking through entity
 +               ((ServerPlayer) p_150716_).getBukkitEntity().updateInventory(); // SPIGOT-4541

--- a/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BucketItem.java.patch
@@ -59,7 +59,7 @@
 +                  // CraftBukkit start
 +                  ItemStack dummyFluid = bucketpickup.m_142598_(DummyGeneratorAccess.INSTANCE, blockpos, blockstate1);
 +                  if (dummyFluid.m_41619_()) return InteractionResultHolder.m_19100_(itemstack); // Don't fire event if the bucket won't be filled.
-+                  PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent((ServerLevel) p_40703_, p_40704_, blockpos, blockpos, blockhitresult.m_82434_(), itemstack, dummyFluid.m_41720_());
++                  PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent(p_40703_, p_40704_, blockpos, blockpos, blockhitresult.m_82434_(), itemstack, dummyFluid.m_41720_());
 +                  if (event.isCancelled()) {
 +                     ((ServerPlayer) p_40704_).f_8906_.m_141995_(new ClientboundBlockUpdatePacket(p_40703_, blockpos)); // SPIGOT-5163 (see PlayerInteractManager)
 +                     ((ServerPlayer) p_40704_).getBukkitEntity().updateInventory(); // SPIGOT-4541
@@ -133,7 +133,7 @@
 +         var enumdirection = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureDirection();
 +         var itemstack = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureItemStack();
 +         if (flag1 && p_150716_ != null) {
-+            PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent((ServerLevel) p_150717_, p_150716_, p_150718_, clicked == null ? BlockPos.f_121853_ : clicked, enumdirection == null ? enumdirection = Direction.UP : enumdirection, itemstack == null ? ItemStack.f_41583_ : itemstack);
++            PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent(p_150717_, p_150716_, p_150718_, clicked == null ? BlockPos.f_121853_ : clicked, enumdirection == null ? enumdirection = Direction.UP : enumdirection, itemstack == null ? ItemStack.f_41583_ : itemstack);
 +            if (event.isCancelled()) {
 +               ((ServerPlayer) p_150716_).f_8906_.m_141995_(new ClientboundBlockUpdatePacket(p_150717_, p_150718_)); // SPIGOT-4238: needed when looking through entity
 +               ((ServerPlayer) p_150716_).getBukkitEntity().updateInventory(); // SPIGOT-4541

--- a/patches/minecraft/net/minecraft/world/level/LevelAccessor.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/LevelAccessor.java.patch
@@ -8,10 +8,14 @@
  import net.minecraft.sounds.SoundEvent;
  import net.minecraft.sounds.SoundSource;
  import net.minecraft.world.Difficulty;
-@@ -100,4 +_,6 @@
+@@ -99,5 +_,10 @@
+ 
     default void m_151545_(@Nullable Entity p_151546_, GameEvent p_151547_, Entity p_151548_) {
        this.m_142346_(p_151546_, p_151547_, p_151548_.m_142538_());
-    }
++   }
 +
-+   ServerLevel getMinecraftWorld(); // CraftBukkit
++   // CatServer - Can't be solved, at least don't throw AbstractMethodError
++   default ServerLevel getMinecraftWorld() {
++      throw new UnsupportedOperationException(String.format("Unsupported Operation! Please report to https://github.com/Luohuayu/CatServer/issues (World class: %s)", getClass().getName()));
+    }
  }

--- a/src/main/java/catserver/server/utils/WorldCheck.java
+++ b/src/main/java/catserver/server/utils/WorldCheck.java
@@ -1,0 +1,18 @@
+package catserver.server.utils;
+
+import catserver.server.CatServer;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.ServerLevelAccessor;
+
+public class WorldCheck {
+    public static boolean isServerWorld(LevelAccessor iWorld) {
+        if (iWorld instanceof ServerLevelAccessor) {
+            return true;
+        } else if (iWorld != null) {
+            CatServer.LOGGER.debug(String.format("Can't handle world: %s", iWorld.getClass().getName()));
+        } else {
+            CatServer.LOGGER.debug(new NullPointerException("Why iWorld is null?"));
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/bukkit/craftbukkit/v1_18_R2/event/CraftEventFactory.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_18_R2/event/CraftEventFactory.java
@@ -229,7 +229,11 @@ public class CraftEventFactory {
     public static Entity entityDamage; // For use in EntityDamageByEntityEvent
 
     // helper methods
-    private static boolean canBuild(Level world, Player player, int x, int z) {
+    private static boolean canBuild(ServerLevel world, Player player, int x, int z) {
+        return canBuild_Modded(world, player, x, z); // CatServer
+    }
+
+    private static boolean canBuild_Modded(Level world, Player player, int x, int z) {
         int spawnSize = Bukkit.getServer().getSpawnRadius();
 
         if (world.dimension() != Level.OVERWORLD) return true;
@@ -237,10 +241,18 @@ public class CraftEventFactory {
         if (((CraftServer) Bukkit.getServer()).getHandle().getOps().isEmpty()) return true;
         if (player.isOp()) return true;
 
-        BlockPos chunkcoordinates = new BlockPos(world.levelData.getXSpawn(), world.levelData.getYSpawn(), world.levelData.getZSpawn());
-        if (!world.getWorldBorder().isWithinBounds(chunkcoordinates)) {
-            chunkcoordinates = world.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, new BlockPos(world.getWorldBorder().getCenterX(), 0.0D, world.getWorldBorder().getCenterZ()));
+        BlockPos chunkcoordinates;
+        if (world instanceof ServerLevel) {
+            // CatServer - Default method
+            chunkcoordinates = ((ServerLevel) world).getSharedSpawnPos();
+        } else {
+            // CatServer - Fallback method
+            chunkcoordinates = new BlockPos(world.levelData.getXSpawn(), world.levelData.getYSpawn(), world.levelData.getZSpawn());
+            if (!world.getWorldBorder().isWithinBounds(chunkcoordinates)) {
+                chunkcoordinates = world.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, new BlockPos(world.getWorldBorder().getCenterX(), 0.0D, world.getWorldBorder().getCenterZ()));
+            }
         }
+
 
         int distanceFromSpawn = Math.max(Math.abs(x - chunkcoordinates.getX()), Math.abs(z - chunkcoordinates.getZ()));
         return distanceFromSpawn > spawnSize;
@@ -330,7 +342,7 @@ public class CraftEventFactory {
     /**
      * Block place methods
      */
-    public static BlockMultiPlaceEvent callBlockMultiPlaceEvent(Level world, net.minecraft.world.entity.player.Player who, InteractionHand hand, List<BlockState> blockStates, int clickedX, int clickedY, int clickedZ) {
+    public static BlockMultiPlaceEvent callBlockMultiPlaceEvent(ServerLevel world, net.minecraft.world.entity.player.Player who, InteractionHand hand, List<BlockState> blockStates, int clickedX, int clickedY, int clickedZ) {
         CraftWorld craftWorld = world.getWorld();
         CraftServer craftServer = world.getCraftServer();
         Player player = (Player) who.getBukkitEntity();
@@ -358,7 +370,7 @@ public class CraftEventFactory {
         return event;
     }
 
-    public static BlockPlaceEvent callBlockPlaceEvent(Level world, net.minecraft.world.entity.player.Player who, InteractionHand hand, BlockState replacedBlockState, int clickedX, int clickedY, int clickedZ) {
+    public static BlockPlaceEvent callBlockPlaceEvent(ServerLevel world, net.minecraft.world.entity.player.Player who, InteractionHand hand, BlockState replacedBlockState, int clickedX, int clickedY, int clickedZ) {
         CraftWorld craftWorld = world.getWorld();
         CraftServer craftServer = world.getCraftServer();
 
@@ -414,15 +426,28 @@ public class CraftEventFactory {
     /**
      * Bucket methods
      */
+    // CatServer - Compatible with modded world
     public static PlayerBucketEmptyEvent callPlayerBucketEmptyEvent(Level world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemInHand) {
-        return (PlayerBucketEmptyEvent) getPlayerBucketEvent(false, world, who, changed, clicked, clickedFace, itemInHand, Items.BUCKET);
+        return (PlayerBucketEmptyEvent) getPlayerBucketEvent_Modded(false, world, who, changed, clicked, clickedFace, itemInHand, Items.BUCKET);
     }
 
     public static PlayerBucketFillEvent callPlayerBucketFillEvent(Level world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemInHand, net.minecraft.world.item.Item bucket) {
-        return (PlayerBucketFillEvent) getPlayerBucketEvent(true, world, who, clicked, changed, clickedFace, itemInHand, bucket);
+        return (PlayerBucketFillEvent) getPlayerBucketEvent_Modded(true, world, who, clicked, changed, clickedFace, itemInHand, bucket);
     }
 
-    private static PlayerEvent getPlayerBucketEvent(boolean isFilling, Level world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemstack, net.minecraft.world.item.Item item) {
+    public static PlayerBucketEmptyEvent callPlayerBucketEmptyEvent(ServerLevel world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemInHand) {
+        return (PlayerBucketEmptyEvent) getPlayerBucketEvent_Modded(false, world, who, changed, clicked, clickedFace, itemInHand, Items.BUCKET);
+    }
+
+    public static PlayerBucketFillEvent callPlayerBucketFillEvent(ServerLevel world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemInHand, net.minecraft.world.item.Item bucket) {
+        return (PlayerBucketFillEvent) getPlayerBucketEvent_Modded(true, world, who, clicked, changed, clickedFace, itemInHand, bucket);
+    }
+
+    private static PlayerEvent getPlayerBucketEvent(boolean isFilling, ServerLevel world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemstack, net.minecraft.world.item.Item item) {
+        return getPlayerBucketEvent_Modded(isFilling, world, who, changed, clicked, clickedFace, itemstack, item);
+    }
+
+    private static PlayerEvent getPlayerBucketEvent_Modded(boolean isFilling, Level world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemstack, net.minecraft.world.item.Item item) {
         Player player = (Player) who.getBukkitEntity();
         CraftItemStack itemInHand = CraftItemStack.asNewCraftStack(item);
         Material bucket = CraftMagicNumbers.getMaterial(itemstack.getItem());
@@ -436,10 +461,10 @@ public class CraftEventFactory {
         PlayerEvent event;
         if (isFilling) {
             event = new PlayerBucketFillEvent(player, block, blockClicked, blockFace, bucket, itemInHand);
-            ((PlayerBucketFillEvent) event).setCancelled(!canBuild(world, player, changed.getX(), changed.getZ()));
+            ((PlayerBucketFillEvent) event).setCancelled(!canBuild_Modded(world, player, changed.getX(), changed.getZ()));
         } else {
             event = new PlayerBucketEmptyEvent(player, block, blockClicked, blockFace, bucket, itemInHand);
-            ((PlayerBucketEmptyEvent) event).setCancelled(!canBuild(world, player, changed.getX(), changed.getZ()));
+            ((PlayerBucketEmptyEvent) event).setCancelled(!canBuild_Modded(world, player, changed.getX(), changed.getZ()));
         }
 
         craftServer.getPluginManager().callEvent(event);


### PR DESCRIPTION
修复机械动力自己实现的 Level 子类没法在 CatServer cast 成 ServerLevel 的 bug

它的作者写了个 level 的子类，在 bucket 互动时给这个level子类传到 bukkit eventbus 当参数去发事件了
导致这个自定义的 level 子类无法 cast 为 ServerLevel 从而服务端崩溃


```java
java.lang.ClassCastException: class com.simibubi.create.content.kinetics.deployer.DeployerHandler$ItemUseWorld 
cannot be cast to class net.minecraft.server.level.ServerLevel (com.simibubi.create.content.kinetics.deployer.DeployerHandler$ItemUseWorld is in module create@0.5.1.f of loader 'TRANSFORMER' @162c1dfb; net.minecraft.server.level.ServerLevel is in module minecraft@1.18.2 of loader 'TRANSFORMER' @162c1dfb)
	at net.minecraft.world.item.BucketItem.emptyContents(BucketItem.java:173) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,xf:fml:forge:bucketitem,re:classloading,xf:fml:forge:bucketitem,pl:mixin:APP:architectury-common.mixins.json:inject.MixinBucketItem,pl:mixin:A}
	at net.minecraft.world.item.BucketItem.emptyContents(BucketItem.java:143) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,xf:fml:forge:bucketitem,re:classloading,xf:fml:forge:bucketitem,pl:mixin:APP:architectury-common.mixins.json:inject.MixinBucketItem,pl:mixin:A}
	at net.minecraft.world.item.BucketItem.m_7203_(BucketItem.java:108) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,xf:fml:forge:bucketitem,re:classloading,xf:fml:forge:bucketitem,pl:mixin:APP:architectury-common.mixins.json:inject.MixinBucketItem,pl:mixin:A}
	at com.simibubi.create.content.kinetics.deployer.DeployerHandler.activateInner(DeployerHandler.java:338) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:classloading}
	at com.simibubi.create.content.kinetics.deployer.DeployerHandler.activate(DeployerHandler.java:135) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:classloading}
	at com.simibubi.create.content.kinetics.deployer.DeployerMovementBehaviour.activate(DeployerMovementBehaviour.java:106) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:classloading}
	at com.simibubi.create.content.kinetics.deployer.DeployerMovementBehaviour.visitNewPosition(DeployerMovementBehaviour.java:75) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:classloading}
	at com.simibubi.create.content.contraptions.AbstractContraptionEntity.tickActors(AbstractContraptionEntity.java:460) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A}
	at com.simibubi.create.content.contraptions.OrientedContraptionEntity.tickContraption(OrientedContraptionEntity.java:280) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:classloading,pl:runtimedistcleaner:A,re:mixin,pl:runtimedistcleaner:A}
	at com.simibubi.create.content.contraptions.AbstractContraptionEntity.m_8119_(AbstractContraptionEntity.java:373) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.world.entity.Entity.m_6083_(Entity.java:1947) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:create.mixins.json:EntityMixin,pl:mixin:APP:mixins.artifacts.json:item.aquadashers.EntityMixin,pl:mixin:APP:mixins.artifacts.json:item.umbrella.EntityMixin,pl:mixin:APP:railways-common.mixins.json:conductor_possession.MixinEntity,pl:mixin:APP:quark.mixins.json:EntityMixin,pl:mixin:APP:mixins.irons_spellbooks.json:EntityMixin,pl:mixin:APP:expandability.mixins.json:fluidcollision.EntityMixin,pl:mixin:APP:expandability.mixins.json:swimming.EntityMixin,pl:mixin:APP:domesticationinnovation.mixins.json:EntityMixin,pl:mixin:APP:create.mixins.json:ContraptionDriverInteractMixin,pl:mixin:A}
	at net.minecraft.server.level.ServerLevel.m_8662_(ServerLevel.java:836) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:observable.common.json:ServerLevelMixin,pl:mixin:APP:create.mixins.json:accessor.ServerLevelAccessor,pl:mixin:A}
	at net.minecraft.server.level.ServerLevel.m_8647_(ServerLevel.java:820) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:observable.common.json:ServerLevelMixin,pl:mixin:APP:create.mixins.json:accessor.ServerLevelAccessor,pl:mixin:A}
	at net.minecraft.world.level.Level.m_46653_(Level.java:1372) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,pl:accesstransformer:B,xf:fml:beefix:Level,re:classloading,pl:accesstransformer:B,xf:fml:beefix:Level,pl:mixin:APP:observable.common.json:LevelMixin,pl:mixin:A}
	at net.minecraft.server.level.ServerLevel.lambda$tick$6(ServerLevel.java:439) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:observable.common.json:ServerLevelMixin,pl:mixin:APP:create.mixins.json:accessor.ServerLevelAccessor,pl:mixin:A}
	at net.minecraft.world.level.entity.EntityTickList.m_156910_(EntityTickList.java:54) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:classloading}
	at net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:419) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:observable.common.json:ServerLevelMixin,pl:mixin:APP:create.mixins.json:accessor.ServerLevelAccessor,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:1229) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.server.dedicated.DedicatedServer.m_5703_(DedicatedServer.java:397) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:1144) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:984) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_177918_(MinecraftServer.java:344) ~[server-1.18.2-20220404.173914-srg.jar%23133!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at java.lang.Thread.run(Thread.java:833) [?:?] {re:mixin}

```


排查发现对应的几个需要强转的事件是为了一个 canBuild 里的 getSharedSpawnPos 逻辑，这个逻辑可以单独抽出来
从而避免桶事件相关模组的强转问题

测试结果：机械臂模拟level的水桶正常放出
![image](https://github.com/Luohuayu/CatServer/assets/36336351/58ae608c-df93-456a-ba4e-2c038d377467)
