### PR TITLE
Handle explosion event and pass to Bukkit properly

### DIFF
--- a/patches/net/minecraft/world/Explosion.java.patch
+++ b/patches/net/minecraft/world/Explosion.java.patch
@@ -29,8 +29,9 @@
      private final double y;
      private final double z;
 -    private final Entity exploder;
+-    private final float size;
 +    public final Entity exploder;
-     private final float size;
++    public float size; // CatServer - private final -> public
      private final List<BlockPos> affectedBlockPositions;
      private final Map<EntityPlayer, Vec3d> playerKnockbackMap;
 +    private final Vec3d position;

--- a/src/main/java/catserver/server/CatServerConfig.java
+++ b/src/main/java/catserver/server/CatServerConfig.java
@@ -44,6 +44,8 @@ public class CatServerConfig {
 
     public boolean waitForgeServerChatEvent = false;
 
+    public boolean bridgeForgeExplosionEventToBukkit = true;
+
     public int craftRequestThrottle = 20;
     public int itemNBTThrottle = 200;
     public boolean limitFastClickGUI = false;
@@ -103,6 +105,8 @@ public class CatServerConfig {
         releaseUseItemThrottle = getOrWriteIntConfig("network.packetLimit.releaseUseItemThrottle", releaseUseItemThrottle);
         disableFMLHandshake = getOrWriteBooleanConfig("network.fml.disableHandshake", config.getBoolean("disableFMLHandshake", disableFMLHandshake));
         disableFMLStatusModInfo = getOrWriteBooleanConfig("network.fml.disableStatusModInfo", config.getBoolean("disableFMLStatusModInfo", disableFMLStatusModInfo));
+        // Event bridge
+        bridgeForgeExplosionEventToBukkit = getOrWriteBooleanConfig("event-bridge.bridgeForgeExplosionEventToBukkit", bridgeForgeExplosionEventToBukkit);
         // general
         disableUpdateGameProfile = getOrWriteBooleanConfig("disableUpdateGameProfile", disableUpdateGameProfile);
         disableAsyncCatchWarn = getOrWriteBooleanConfig("disableAsyncCatchWarn", disableAsyncCatchWarn);

--- a/src/main/java/catserver/server/CatServerEventHandler.java
+++ b/src/main/java/catserver/server/CatServerEventHandler.java
@@ -1,16 +1,25 @@
 package catserver.server;
 
+import com.google.common.collect.Lists;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.Explosion;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.event.world.ExplosionEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.craftbukkit.block.CraftBlockState;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -18,7 +27,9 @@ import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.Event;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 
 import java.util.ArrayList;
@@ -63,6 +74,54 @@ public class CatServerEventHandler {
 
         if (bukkitEvent.isCancelled() || !bukkitEvent.canBuild()) {
             event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void onExplode(ExplosionEvent.Detonate event) {
+        Explosion explosion = event.getExplosion();
+        if (explosion.getClass() != Explosion.class) {
+            Entity exploder = explosion.exploder;
+            World bworld = event.getWorld().getWorld();
+            Vec3d explosionPos = explosion.getPosition();
+            Location location = new Location(bworld, explosionPos.x, explosionPos.y, explosionPos.z);
+            List<Block> bukkitBlocks;
+            boolean cancelled;
+            float yield;
+            final List<Block> blockList = Lists.newArrayList();
+            List<BlockPos> affectedBlockPositions = event.getAffectedBlocks();
+            for (int i1 = affectedBlockPositions.size() - 1; i1 >= 0; i1--) {
+                BlockPos cpos = affectedBlockPositions.get(i1);
+                Block bblock = bworld.getBlockAt(cpos.getX(), cpos.getY(), cpos.getZ());
+                if (bblock.getType() != Material.AIR) {
+                    blockList.add(bblock);
+                }
+            }
+            if (exploder != null) {
+                EntityExplodeEvent bukkitEvent = new EntityExplodeEvent(exploder.getBukkitEntity(), location , blockList, 1.0F / explosion.size);
+                Bukkit.getServer().getPluginManager().callEvent(bukkitEvent);
+                cancelled = bukkitEvent.isCancelled();
+                bukkitBlocks = bukkitEvent.blockList();
+                yield = bukkitEvent.getYield();
+            } else {
+                BlockExplodeEvent bukkitEvent = new BlockExplodeEvent(location.getBlock(), blockList, 1.0F / explosion.size);
+                Bukkit.getServer().getPluginManager().callEvent(bukkitEvent);
+                cancelled = bukkitEvent.isCancelled();
+                bukkitBlocks = bukkitEvent.blockList();
+                yield = bukkitEvent.getYield();
+            }
+            explosion.getAffectedBlockPositions().clear();
+
+            if (cancelled) {
+                event.getAffectedEntities().clear();
+                explosion.wasCanceled = true;
+            } else {
+                for (Block bblock : bukkitBlocks) {
+                    BlockPos coords = new BlockPos(bblock.getX(), bblock.getY(), bblock.getZ());
+                    explosion.getAffectedBlockPositions().add(coords);
+                }
+                explosion.size = yield * explosion.size;
+            }
         }
     }
 

--- a/src/main/java/catserver/server/CatServerEventHandler.java
+++ b/src/main/java/catserver/server/CatServerEventHandler.java
@@ -79,6 +79,7 @@ public class CatServerEventHandler {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onExplode(ExplosionEvent.Detonate event) {
+        if (!CatServer.getConfig().bridgeForgeExplosionEventToBukkit) return;
         Explosion explosion = event.getExplosion();
         if (explosion.getClass() != Explosion.class) {
             Entity exploder = explosion.exploder;


### PR DESCRIPTION
This pull request fixes some mod items with custom explosions cannot be processed properly by Bukkit plugins.

Requires mods to call ExplosionEvent correctly(Most of them did well)

Tested with Tinkers' Construct EFLN, works fine.