### PR TITLE
Fix MCEternal

### DIFF
--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -42,7 +42,7 @@
  import net.minecraft.pathfinding.PathWorldListener;
  import net.minecraft.profiler.Profiler;
  import net.minecraft.scoreboard.Scoreboard;
-@@ -43,28 +51,45 @@
+@@ -43,28 +51,46 @@
  import net.minecraft.util.ReportedException;
  import net.minecraft.util.SoundCategory;
  import net.minecraft.util.SoundEvent;
@@ -91,10 +91,11 @@
 +     */
 +    public static double MAX_ENTITY_RADIUS = 2.0D;
 +
++    private int tilesThisCycle = 0; // CatServer - Move up to keep LVT clean
      private int seaLevel = 63;
      protected boolean scheduledUpdatesAreImmediate;
      public final List<Entity> loadedEntityList = Lists.<Entity>newArrayList();
-@@ -86,30 +111,149 @@
+@@ -86,30 +112,149 @@
      public float thunderingStrength;
      private int lastLightningBolt;
      public final Random rand = new Random();
@@ -250,7 +251,7 @@
          this.eventListeners = Lists.newArrayList(this.pathListener);
          this.calendar = Calendar.getInstance();
          this.worldScoreboard = new Scoreboard();
-@@ -122,6 +266,10 @@
+@@ -122,6 +267,10 @@
          this.provider = providerIn;
          this.isRemote = client;
          this.worldBorder = providerIn.createWorldBorder();
@@ -261,7 +262,7 @@
      }
  
      public World init()
-@@ -131,6 +279,11 @@
+@@ -131,6 +280,11 @@
  
      public Biome getBiome(final BlockPos pos)
      {
@@ -273,7 +274,7 @@
          if (this.isBlockLoaded(pos))
          {
              Chunk chunk = this.getChunkFromBlockCoords(pos);
-@@ -207,7 +360,7 @@
+@@ -207,7 +361,7 @@
  
      public boolean isAirBlock(BlockPos pos)
      {
@@ -282,7 +283,7 @@
      }
  
      public boolean isBlockLoaded(BlockPos pos)
-@@ -278,7 +431,7 @@
+@@ -278,7 +432,7 @@
          }
      }
  
@@ -291,7 +292,7 @@
  
      public Chunk getChunkFromBlockCoords(BlockPos pos)
      {
-@@ -297,6 +450,26 @@
+@@ -297,6 +451,26 @@
  
      public boolean setBlockState(BlockPos pos, IBlockState newState, int flags)
      {
@@ -318,7 +319,7 @@
          if (this.isOutsideBuildHeight(pos))
          {
              return false;
-@@ -308,24 +481,53 @@
+@@ -308,24 +482,53 @@
          else
          {
              Chunk chunk = this.getChunkFromBlockCoords(pos);
@@ -375,7 +376,7 @@
                      this.notifyBlockUpdate(pos, iblockstate, newState, flags);
                  }
  
-@@ -342,8 +544,6 @@
+@@ -342,8 +545,6 @@
                  {
                      this.updateObservingBlocksAt(pos, block);
                  }
@@ -384,7 +385,7 @@
              }
          }
      }
-@@ -358,7 +558,7 @@
+@@ -358,7 +559,7 @@
          IBlockState iblockstate = this.getBlockState(pos);
          Block block = iblockstate.getBlock();
  
@@ -393,7 +394,7 @@
          {
              return false;
          }
-@@ -392,6 +592,9 @@
+@@ -392,6 +593,9 @@
      {
          if (this.worldInfo.getTerrainType() != WorldType.DEBUG_ALL_BLOCK_STATES)
          {
@@ -403,7 +404,7 @@
              this.notifyNeighborsOfStateChange(pos, blockType, p_175722_3_);
          }
      }
-@@ -441,6 +644,9 @@
+@@ -441,6 +645,9 @@
  
      public void notifyNeighborsOfStateChange(BlockPos pos, Block blockType, boolean updateObservers)
      {
@@ -413,7 +414,7 @@
          this.neighborChanged(pos.west(), blockType, pos);
          this.neighborChanged(pos.east(), blockType, pos);
          this.neighborChanged(pos.down(), blockType, pos);
-@@ -456,6 +662,11 @@
+@@ -456,6 +663,11 @@
  
      public void notifyNeighborsOfStateExcept(BlockPos pos, Block blockType, EnumFacing skipSide)
      {
@@ -425,7 +426,7 @@
          if (skipSide != EnumFacing.WEST)
          {
              this.neighborChanged(pos.west(), blockType, pos);
-@@ -495,6 +706,15 @@
+@@ -495,6 +707,15 @@
  
              try
              {
@@ -441,7 +442,7 @@
                  iblockstate.neighborChanged(this, pos, blockIn, fromPos);
              }
              catch (Throwable throwable)
-@@ -507,7 +727,7 @@
+@@ -507,7 +728,7 @@
                      {
                          try
                          {
@@ -450,7 +451,7 @@
                          }
                          catch (Throwable var2)
                          {
-@@ -527,12 +747,17 @@
+@@ -527,12 +748,17 @@
          {
              IBlockState iblockstate = this.getBlockState(pos);
  
@@ -470,7 +471,7 @@
                  catch (Throwable throwable)
                  {
                      CrashReport crashreport = CrashReport.makeCrashReport(throwable, "Exception while updating neighbours");
-@@ -588,7 +813,7 @@
+@@ -588,7 +814,7 @@
                  {
                      IBlockState iblockstate = this.getBlockState(blockpos1);
  
@@ -479,7 +480,7 @@
                      {
                          return false;
                      }
-@@ -849,12 +1074,24 @@
+@@ -849,12 +1075,24 @@
  
      public IBlockState getBlockState(BlockPos pos)
      {
@@ -504,7 +505,7 @@
              Chunk chunk = this.getChunkFromBlockCoords(pos);
              return chunk.getBlockState(pos);
          }
-@@ -862,7 +1099,7 @@
+@@ -862,7 +1100,7 @@
  
      public boolean isDaytime()
      {
@@ -513,7 +514,7 @@
      }
  
      @Nullable
-@@ -1065,6 +1302,13 @@
+@@ -1065,6 +1303,13 @@
  
      public void playSound(@Nullable EntityPlayer player, double x, double y, double z, SoundEvent soundIn, SoundCategory category, float volume, float pitch)
      {
@@ -527,7 +528,7 @@
          for (int i = 0; i < this.eventListeners.size(); ++i)
          {
              ((IWorldEventListener)this.eventListeners.get(i)).playSoundToAllNearExcept(player, soundIn, category, x, y, z, volume, pitch);
-@@ -1112,17 +1356,76 @@
+@@ -1112,17 +1357,76 @@
  
      public boolean addWeatherEffect(Entity entityIn)
      {
@@ -608,7 +609,7 @@
          {
              flag = true;
          }
-@@ -1133,16 +1436,18 @@
+@@ -1133,16 +1437,18 @@
          }
          else
          {
@@ -632,7 +633,7 @@
              return true;
          }
      }
-@@ -1153,6 +1458,8 @@
+@@ -1153,6 +1459,8 @@
          {
              ((IWorldEventListener)this.eventListeners.get(i)).onEntityAdded(entityIn);
          }
@@ -641,7 +642,7 @@
      }
  
      public void onEntityRemoved(Entity entityIn)
-@@ -1161,10 +1468,13 @@
+@@ -1161,10 +1469,13 @@
          {
              ((IWorldEventListener)this.eventListeners.get(i)).onEntityRemoved(entityIn);
          }
@@ -655,7 +656,7 @@
          if (entityIn.isBeingRidden())
          {
              entityIn.removePassengers();
-@@ -1187,6 +1497,7 @@
+@@ -1187,6 +1498,7 @@
  
      public void removeEntityDangerously(Entity entityIn)
      {
@@ -663,7 +664,7 @@
          entityIn.setDropItemsWhenDead(false);
          entityIn.setDead();
  
-@@ -1204,7 +1515,16 @@
+@@ -1204,7 +1516,16 @@
              this.getChunkFromChunkCoords(i, j).removeEntity(entityIn);
          }
  
@@ -681,7 +682,7 @@
          this.onEntityRemoved(entityIn);
      }
  
-@@ -1227,6 +1547,7 @@
+@@ -1227,6 +1548,7 @@
          IBlockState iblockstate = Blocks.STONE.getDefaultState();
          BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.retain();
  
@@ -689,7 +690,7 @@
          try
          {
              for (int k1 = i; k1 < j; ++k1)
-@@ -1269,7 +1590,7 @@
+@@ -1269,7 +1591,7 @@
  
                                  iblockstate1.addCollisionBoxToList(this, blockpos$pooledmutableblockpos, aabb, outList, entityIn, false);
  
@@ -698,7 +699,7 @@
                                  {
                                      boolean flag5 = true;
                                      return flag5;
-@@ -1319,11 +1640,10 @@
+@@ -1319,11 +1641,10 @@
                  }
              }
          }
@@ -711,7 +712,7 @@
      public void removeEventListener(IWorldEventListener listener)
      {
          this.eventListeners.remove(listener);
-@@ -1361,19 +1681,38 @@
+@@ -1361,19 +1682,38 @@
  
      public int calculateSkylightSubtracted(float partialTicks)
      {
@@ -752,7 +753,7 @@
          float f = this.getCelestialAngle(partialTicks);
          float f1 = 1.0F - (MathHelper.cos(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.clamp(f1, 0.0F, 1.0F);
-@@ -1386,6 +1725,12 @@
+@@ -1386,6 +1726,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d getSkyColor(Entity entityIn, float partialTicks)
      {
@@ -765,7 +766,7 @@
          float f = this.getCelestialAngle(partialTicks);
          float f1 = MathHelper.cos(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.clamp(f1, 0.0F, 1.0F);
-@@ -1393,9 +1738,7 @@
+@@ -1393,9 +1739,7 @@
          int j = MathHelper.floor(entityIn.posY);
          int k = MathHelper.floor(entityIn.posZ);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -776,7 +777,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1444,20 +1787,25 @@
+@@ -1444,20 +1788,25 @@
  
      public float getCelestialAngle(float partialTicks)
      {
@@ -805,7 +806,7 @@
      public float getCelestialAngleRadians(float partialTicks)
      {
          float f = this.getCelestialAngle(partialTicks);
-@@ -1467,6 +1815,12 @@
+@@ -1467,6 +1816,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d getCloudColour(float partialTicks)
      {
@@ -818,7 +819,7 @@
          float f = this.getCelestialAngle(partialTicks);
          float f1 = MathHelper.cos(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.clamp(f1, 0.0F, 1.0F);
-@@ -1522,9 +1876,9 @@
+@@ -1522,9 +1877,9 @@
          for (blockpos = new BlockPos(pos.getX(), chunk.getTopFilledSegment() + 16, pos.getZ()); blockpos.getY() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.down();
@@ -830,7 +831,7 @@
              {
                  break;
              }
-@@ -1536,6 +1890,12 @@
+@@ -1536,6 +1891,12 @@
      @SideOnly(Side.CLIENT)
      public float getStarBrightness(float partialTicks)
      {
@@ -843,7 +844,7 @@
          float f = this.getCelestialAngle(partialTicks);
          float f1 = 1.0F - (MathHelper.cos(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.clamp(f1, 0.0F, 1.0F);
-@@ -1567,9 +1927,14 @@
+@@ -1567,9 +1928,14 @@
          for (int i = 0; i < this.weatherEffects.size(); ++i)
          {
              Entity entity = this.weatherEffects.get(i);
@@ -859,7 +860,7 @@
                  ++entity.ticksExisted;
                  entity.onUpdate();
              }
-@@ -1587,6 +1952,12 @@
+@@ -1587,6 +1953,12 @@
                      entity.addEntityCrashInfo(crashreportcategory);
                  }
  
@@ -872,7 +873,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1620,9 +1991,20 @@
+@@ -1620,9 +1992,20 @@
          this.tickPlayers();
          this.profiler.endStartSection("regular");
  
@@ -896,7 +897,7 @@
              Entity entity3 = entity2.getRidingEntity();
  
              if (entity3 != null)
-@@ -1641,13 +2023,25 @@
+@@ -1641,13 +2024,25 @@
              {
                  try
                  {
@@ -922,7 +923,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1665,34 +2059,59 @@
+@@ -1665,34 +2060,59 @@
                      this.getChunkFromChunkCoords(l1, i2).removeEntity(entity2);
                  }
  
@@ -961,14 +962,14 @@
 -        this.processingLoadedTiles = true;
 -        Iterator<TileEntity> iterator = this.tickableTileEntities.iterator();
 +        // Iterator<TileEntity> iterator = this.tickableTileEntities.iterator();
-+        Iterator<TileEntity> iterator = null; // The code is no used, but do not remove, if remove will asm boom
++        Iterator<TileEntity> iterator = this.tickableTileEntities.iterator(); // The code is no used, but do not remove, if remove will asm boom
  
 -        while (iterator.hasNext())
 -        {
 -            TileEntity tileentity = iterator.next();
 -
 +        { // CatServer - Dont break asm
-+        int tilesThisCycle = 0;
++        tilesThisCycle = 0; // CatServer - reset value
 +        for (tileLimiter.initTick();
 +             tilesThisCycle < this.tickableTileEntities.size() && (tilesThisCycle % 10 != 0 || tileLimiter.shouldContinue());
 +             tileTickPosition++, tilesThisCycle++) {
@@ -992,7 +993,7 @@
                  {
                      try
                      {
-@@ -1700,7 +2119,12 @@
+@@ -1700,7 +2120,12 @@
                          {
                              return String.valueOf((Object)TileEntity.getKey(tileentity.getClass()));
                          });
@@ -1005,7 +1006,7 @@
                          this.profiler.endSection();
                      }
                      catch (Throwable throwable)
-@@ -1708,23 +2132,43 @@
+@@ -1708,23 +2133,43 @@
                          CrashReport crashreport2 = CrashReport.makeCrashReport(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.makeCategory("Block entity being ticked");
                          tileentity.addInfoToCrashReport(crashreportcategory2);
@@ -1051,7 +1052,7 @@
          this.processingLoadedTiles = false;
          this.profiler.endStartSection("pendingBlockEntities");
  
-@@ -1736,10 +2180,12 @@
+@@ -1736,10 +2181,12 @@
  
                  if (!tileentity1.isInvalid())
                  {
@@ -1064,7 +1065,7 @@
  
                      if (this.isBlockLoaded(tileentity1.getPos()))
                      {
-@@ -1747,6 +2193,12 @@
+@@ -1747,6 +2194,12 @@
                          IBlockState iblockstate = chunk.getBlockState(tileentity1.getPos());
                          chunk.addTileEntity(tileentity1.getPos(), tileentity1);
                          this.notifyBlockUpdate(tileentity1.getPos(), iblockstate, iblockstate, 3);
@@ -1077,7 +1078,7 @@
                      }
                  }
              }
-@@ -1754,6 +2206,7 @@
+@@ -1754,6 +2207,7 @@
              this.addedTileEntityList.clear();
          }
  
@@ -1085,7 +1086,7 @@
          this.profiler.endSection();
          this.profiler.endSection();
      }
-@@ -1764,12 +2217,18 @@
+@@ -1764,12 +2218,18 @@
  
      public boolean addTileEntity(TileEntity tile)
      {
@@ -1104,7 +1105,7 @@
  
          if (this.isRemote)
          {
-@@ -1785,6 +2244,11 @@
+@@ -1785,6 +2245,11 @@
      {
          if (this.processingLoadedTiles)
          {
@@ -1116,7 +1117,7 @@
              this.addedTileEntityList.addAll(tileEntityCollection);
          }
          else
-@@ -1807,14 +2271,26 @@
+@@ -1807,14 +2272,26 @@
          {
              int j2 = MathHelper.floor(entityIn.posX);
              int k2 = MathHelper.floor(entityIn.posZ);
@@ -1145,7 +1146,7 @@
          entityIn.lastTickPosX = entityIn.posX;
          entityIn.lastTickPosY = entityIn.posY;
          entityIn.lastTickPosZ = entityIn.posZ;
-@@ -1831,7 +2307,9 @@
+@@ -1831,7 +2308,9 @@
              }
              else
              {
@@ -1155,7 +1156,7 @@
              }
          }
  
-@@ -1914,7 +2392,7 @@
+@@ -1914,7 +2393,7 @@
          {
              Entity entity4 = list.get(j2);
  
@@ -1164,7 +1165,7 @@
              {
                  return false;
              }
-@@ -1972,6 +2450,12 @@
+@@ -1972,6 +2451,12 @@
                  {
                      IBlockState iblockstate1 = this.getBlockState(blockpos$pooledmutableblockpos.setPos(l3, i4, j4));
  
@@ -1177,7 +1178,7 @@
                      if (iblockstate1.getMaterial().isLiquid())
                      {
                          blockpos$pooledmutableblockpos.release();
-@@ -2011,6 +2495,11 @@
+@@ -2011,6 +2496,11 @@
                              blockpos$pooledmutableblockpos.release();
                              return true;
                          }
@@ -1189,7 +1190,7 @@
                      }
                  }
              }
-@@ -2050,6 +2539,16 @@
+@@ -2050,6 +2540,16 @@
                          IBlockState iblockstate1 = this.getBlockState(blockpos$pooledmutableblockpos);
                          Block block = iblockstate1.getBlock();
  
@@ -1206,7 +1207,7 @@
                          if (iblockstate1.getMaterial() == materialIn)
                          {
                              double d0 = (double)((float)(i4 + 1) - BlockLiquid.getLiquidHeightPercent(((Integer)iblockstate1.getValue(BlockLiquid.LEVEL)).intValue()));
-@@ -2095,7 +2594,14 @@
+@@ -2095,7 +2595,14 @@
              {
                  for (int j4 = j3; j4 < k3; ++j4)
                  {
@@ -1222,7 +1223,7 @@
                      {
                          blockpos$pooledmutableblockpos.release();
                          return true;
-@@ -2116,6 +2622,7 @@
+@@ -2116,6 +2623,7 @@
      public Explosion newExplosion(@Nullable Entity entityIn, double x, double y, double z, float strength, boolean isFlaming, boolean isSmoking)
      {
          Explosion explosion = new Explosion(this, entityIn, x, y, z, strength, isFlaming, isSmoking);
@@ -1230,7 +1231,7 @@
          explosion.doExplosionA();
          explosion.doExplosionB(true);
          return explosion;
-@@ -2206,7 +2713,7 @@
+@@ -2206,7 +2714,7 @@
                  tileentity2 = this.getPendingTileEntityAt(pos);
              }
  
@@ -1239,7 +1240,7 @@
              {
                  tileentity2 = this.getChunkFromBlockCoords(pos).getTileEntity(pos, Chunk.EnumCreateEntityType.IMMEDIATE);
              }
-@@ -2238,6 +2745,7 @@
+@@ -2238,6 +2746,7 @@
  
      public void setTileEntity(BlockPos pos, @Nullable TileEntity tileEntityIn)
      {
@@ -1247,7 +1248,7 @@
          if (!this.isOutsideBuildHeight(pos))
          {
              if (tileEntityIn != null && !tileEntityIn.isInvalid())
-@@ -2245,7 +2753,10 @@
+@@ -2245,7 +2754,10 @@
                  if (this.processingLoadedTiles)
                  {
                      tileEntityIn.setPos(pos);
@@ -1258,7 +1259,7 @@
  
                      while (iterator1.hasNext())
                      {
-@@ -2253,16 +2764,19 @@
+@@ -2253,16 +2765,19 @@
  
                          if (tileentity2.getPos().equals(pos))
                          {
@@ -1280,7 +1281,7 @@
                      this.addTileEntity(tileEntityIn);
                  }
              }
-@@ -2277,6 +2791,8 @@
+@@ -2277,6 +2792,8 @@
          {
              tileentity2.invalidate();
              this.addedTileEntityList.remove(tileentity2);
@@ -1289,7 +1290,7 @@
          }
          else
          {
-@@ -2289,6 +2805,7 @@
+@@ -2289,6 +2806,7 @@
  
              this.getChunkFromBlockCoords(pos).removeTileEntity(pos);
          }
@@ -1297,7 +1298,7 @@
      }
  
      public void markTileEntityForRemoval(TileEntity tileEntityIn)
-@@ -2315,7 +2832,7 @@
+@@ -2315,7 +2833,7 @@
              if (chunk1 != null && !chunk1.isEmpty())
              {
                  IBlockState iblockstate1 = this.getBlockState(pos);
@@ -1306,7 +1307,7 @@
              }
              else
              {
-@@ -2338,6 +2855,7 @@
+@@ -2338,6 +2856,7 @@
      {
          this.spawnHostileMobs = hostile;
          this.spawnPeacefulMobs = peaceful;
@@ -1314,7 +1315,7 @@
      }
  
      public void tick()
-@@ -2347,6 +2865,11 @@
+@@ -2347,6 +2866,11 @@
  
      protected void calculateInitialWeather()
      {
@@ -1326,7 +1327,7 @@
          if (this.worldInfo.isRaining())
          {
              this.rainingStrength = 1.0F;
-@@ -2360,6 +2883,11 @@
+@@ -2360,6 +2884,11 @@
  
      protected void updateWeather()
      {
@@ -1338,7 +1339,7 @@
          if (this.provider.hasSkyLight())
          {
              if (!this.isRemote)
-@@ -2451,6 +2979,11 @@
+@@ -2451,6 +2980,11 @@
                  }
  
                  this.rainingStrength = MathHelper.clamp(this.rainingStrength, 0.0F, 1.0F);
@@ -1350,7 +1351,7 @@
              }
          }
      }
-@@ -2484,6 +3017,11 @@
+@@ -2484,6 +3018,11 @@
  
      public boolean canBlockFreeze(BlockPos pos, boolean noWaterAdj)
      {
@@ -1362,7 +1363,7 @@
          Biome biome = this.getBiome(pos);
          float f = biome.getTemperature(pos);
  
-@@ -2525,6 +3063,11 @@
+@@ -2525,6 +3064,11 @@
  
      public boolean canSnowAt(BlockPos pos, boolean checkLight)
      {
@@ -1374,7 +1375,7 @@
          Biome biome = this.getBiome(pos);
          float f = biome.getTemperature(pos);
  
-@@ -2542,7 +3085,7 @@
+@@ -2542,7 +3086,7 @@
              {
                  IBlockState iblockstate1 = this.getBlockState(pos);
  
@@ -1383,7 +1384,7 @@
                  {
                      return true;
                  }
-@@ -2574,10 +3117,10 @@
+@@ -2574,10 +3118,10 @@
          else
          {
              IBlockState iblockstate1 = this.getBlockState(pos);
@@ -1397,7 +1398,7 @@
              {
                  k2 = 1;
              }
-@@ -2589,7 +3132,7 @@
+@@ -2589,7 +3133,7 @@
  
              if (k2 >= 15)
              {
@@ -1406,7 +1407,7 @@
              }
              else if (j2 >= 14)
              {
-@@ -2630,12 +3173,16 @@
+@@ -2630,12 +3174,16 @@
  
      public boolean checkLightFor(EnumSkyBlock lightType, BlockPos pos)
      {
@@ -1424,7 +1425,7 @@
              int j2 = 0;
              int k2 = 0;
              this.profiler.startSection("getBrightness");
-@@ -2673,7 +3220,7 @@
+@@ -2673,7 +3221,7 @@
                              int l5 = MathHelper.abs(k4 - k3);
                              int i6 = MathHelper.abs(l4 - l3);
  
@@ -1433,7 +1434,7 @@
                              {
                                  BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.retain();
  
-@@ -2683,7 +3230,8 @@
+@@ -2683,7 +3231,8 @@
                                      int k6 = k4 + enumfacing.getFrontOffsetY();
                                      int l6 = l4 + enumfacing.getFrontOffsetZ();
                                      blockpos$pooledmutableblockpos.setPos(j6, k6, l6);
@@ -1443,7 +1444,7 @@
                                      j5 = this.getLightFor(lightType, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.lightUpdateBlockList.length)
-@@ -2725,7 +3273,7 @@
+@@ -2725,7 +3274,7 @@
                          int j9 = Math.abs(i8 - l3);
                          boolean flag = k2 < this.lightUpdateBlockList.length - 6;
  
@@ -1452,7 +1453,7 @@
                          {
                              if (this.getLightFor(lightType, blockpos2.west()) < k8)
                              {
-@@ -2791,10 +3339,10 @@
+@@ -2791,10 +3340,10 @@
      public List<Entity> getEntitiesInAABBexcluding(@Nullable Entity entityIn, AxisAlignedBB boundingBox, @Nullable Predicate <? super Entity > predicate)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -1467,7 +1468,7 @@
  
          for (int j3 = j2; j3 <= k2; ++j3)
          {
-@@ -2847,10 +3395,10 @@
+@@ -2847,10 +3396,10 @@
  
      public <T extends Entity> List<T> getEntitiesWithinAABB(Class <? extends T > clazz, AxisAlignedBB aabb, @Nullable Predicate <? super T > filter)
      {
@@ -1482,7 +1483,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int j3 = j2; j3 < k2; ++j3)
-@@ -2919,7 +3467,16 @@
+@@ -2919,7 +3468,16 @@
  
          for (Entity entity4 : this.loadedEntityList)
          {
@@ -1500,7 +1501,7 @@
              {
                  ++j2;
              }
-@@ -2930,11 +3487,17 @@
+@@ -2930,11 +3488,17 @@
  
      public void loadEntities(Collection<Entity> entityCollection)
      {
@@ -1521,7 +1522,7 @@
          }
      }
  
-@@ -2948,18 +3511,24 @@
+@@ -2948,18 +3512,24 @@
          IBlockState iblockstate1 = this.getBlockState(pos);
          AxisAlignedBB axisalignedbb = skipCollisionCheck ? null : blockIn.getDefaultState().getCollisionBoundingBox(this, pos);
  
@@ -1550,7 +1551,7 @@
      }
  
      public int getSeaLevel()
-@@ -3042,7 +3611,7 @@
+@@ -3042,7 +3612,7 @@
      public int getRedstonePower(BlockPos pos, EnumFacing facing)
      {
          IBlockState iblockstate1 = this.getBlockState(pos);
@@ -1559,7 +1560,7 @@
      }
  
      public boolean isBlockPowered(BlockPos pos)
-@@ -3124,6 +3693,12 @@
+@@ -3124,6 +3694,12 @@
          {
              EntityPlayer entityplayer1 = this.playerEntities.get(j2);
  
@@ -1572,7 +1573,7 @@
              if (p_190525_9_.apply(entityplayer1))
              {
                  double d1 = entityplayer1.getDistanceSq(x, y, z);
-@@ -3208,6 +3783,8 @@
+@@ -3208,6 +3784,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(playerToDouble.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -1581,7 +1582,7 @@
                  if ((maxYDistance < 0.0D || Math.abs(entityplayer1.posY - posY) < maxYDistance * maxYDistance) && (maxXZDistance < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +3846,7 @@
+@@ -3269,7 +3847,7 @@
  
      public long getSeed()
      {
@@ -1590,7 +1591,7 @@
      }
  
      public long getTotalWorldTime()
-@@ -3279,17 +3856,17 @@
+@@ -3279,17 +3857,17 @@
  
      public long getWorldTime()
      {
@@ -1611,7 +1612,7 @@
  
          if (!this.getWorldBorder().contains(blockpos1))
          {
-@@ -3301,7 +3878,7 @@
+@@ -3301,7 +3879,7 @@
  
      public void setSpawnPoint(BlockPos pos)
      {
@@ -1620,7 +1621,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +3898,18 @@
+@@ -3321,12 +3899,18 @@
  
          if (!this.loadedEntityList.contains(entityIn))
          {
@@ -1639,7 +1640,7 @@
          return true;
      }
  
-@@ -3363,6 +3946,16 @@
+@@ -3363,6 +3947,16 @@
      {
      }
  
@@ -1656,7 +1657,7 @@
      public float getThunderStrength(float delta)
      {
          return (this.prevThunderingStrength + (this.thunderingStrength - this.prevThunderingStrength) * delta) * this.getRainStrength(delta);
-@@ -3428,8 +4021,7 @@
+@@ -3428,8 +4022,7 @@
  
      public boolean isBlockinHighHumidity(BlockPos pos)
      {
@@ -1666,7 +1667,7 @@
      }
  
      @Nullable
-@@ -3490,12 +4082,12 @@
+@@ -3490,12 +4083,12 @@
  
      public int getHeight()
      {
@@ -1681,7 +1682,7 @@
      }
  
      public Random setRandomSeed(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +4131,7 @@
+@@ -3539,7 +4132,7 @@
      @SideOnly(Side.CLIENT)
      public double getHorizon()
      {
@@ -1690,7 +1691,7 @@
      }
  
      public void sendBlockBreakProgress(int breakerId, BlockPos pos, int progress)
-@@ -3573,7 +4165,7 @@
+@@ -3573,7 +4166,7 @@
  
      public void updateComparatorOutputLevel(BlockPos pos, Block blockIn)
      {
@@ -1699,7 +1700,7 @@
          {
              BlockPos blockpos1 = pos.offset(enumfacing);
  
-@@ -3581,18 +4173,15 @@
+@@ -3581,18 +4174,15 @@
              {
                  IBlockState iblockstate1 = this.getBlockState(blockpos1);
  
@@ -1722,7 +1723,7 @@
                      }
                  }
              }
-@@ -3655,9 +4244,127 @@
+@@ -3655,9 +4245,127 @@
          int j2 = x * 16 + 8 - blockpos1.getX();
          int k2 = z * 16 + 8 - blockpos1.getZ();
          int l2 = 128;
@@ -1851,7 +1852,7 @@
      public void sendPacketToServer(Packet<?> packetIn)
      {
          throw new UnsupportedOperationException("Can't send packets to server unless you're on the client.");
-@@ -3673,4 +4380,6 @@
+@@ -3673,4 +4381,6 @@
      {
          return null;
      }


### PR DESCRIPTION
This pull request closes #904.

### Changes made

- Move tilesThisCycle to member variable to keep LVT clean and make Mixin happy
- Make iterator can be captured by Mixin

### Error analysis

**Error log:**
```
[main/ERROR] [mixin]: Critical injection failure: LVT in net/minecraft/world/World::func_72939_s()V has incompatible changes at opcode 787 in callback net/minecraft/world/World::beforeTick.
Expected: [Ljava/util/Iterator;, Lnet/minecraft/tileentity/TileEntity;, Lnet/minecraft/util/math/BlockPos;]
Found: [I, Lnet/minecraft/tileentity/TileEntity;, Lnet/minecraft/util/math/BlockPos;]
```

The original code `Iterator<TileEntity> iterator = null;` will be considered as unused by javac and will be optimized to bytecode like this:
```java
0: aconst_null
1: astore_1

Not real code, just for example.

```
Which causes Iterator is missing in LVT, mod mixins cannot capture the variable and lead to errors. After fixing this, the LVT order should be `[Ljava/util/Iterator;, I, Lnet/minecraft/tileentity/TileEntity;]`

Also `int tilesThisCycle = 0;` statement causes inconsistent order in local variable table, made mixins capture the wrong value. Moving to member var resolves this.