### PR TITLE
re-call AttachCapabilitiesEvent for player

### DIFF
--- a/patches/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/net/minecraft/server/management/PlayerList.java.patch
@@ -617,12 +617,18 @@
          playerIn.dimension = dimension;
          PlayerInteractionManager playerinteractionmanager;
  
-@@ -493,8 +848,14 @@
+@@ -493,8 +848,20 @@
          }
  
          EntityPlayerMP entityplayermp = new EntityPlayerMP(this.mcServer, this.mcServer.getWorld(playerIn.dimension), playerIn.getGameProfile(), playerinteractionmanager);
 +        */
 +        EntityPlayerMP entityplayermp = playerIn;
++        // CatServer start - Call construct event and re-gather capabilities
++        if (catserver.server.CatServer.getConfig().callConstructCapabilityEventOnRespawn) {
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(entityplayermp));
++            ((Entity) entityplayermp).capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(entityplayermp);
++        }
++        // CatServer end - Call construct event and re-gather capabilities
 +        org.bukkit.World fromWorld = playerIn.getBukkitEntity().getWorld();
 +        playerIn.queuedEndExit = false;
 +
@@ -632,7 +638,7 @@
          entityplayermp.setEntityId(playerIn.getEntityId());
          entityplayermp.setCommandStats(playerIn);
          entityplayermp.setPrimaryHand(playerIn.getPrimaryHand());
-@@ -504,44 +865,103 @@
+@@ -504,44 +871,103 @@
              entityplayermp.addTag(s);
          }
  
@@ -757,7 +763,7 @@
          return entityplayermp;
      }
  
-@@ -549,44 +969,125 @@
+@@ -549,44 +975,125 @@
      {
          GameProfile gameprofile = player.getGameProfile();
          int i = this.canSendCommands(gameprofile) ? this.ops.getPermissionLevel(gameprofile) : 0;
@@ -896,7 +902,7 @@
          {
              d0 = MathHelper.clamp(d0 / 8.0D, toWorldIn.getWorldBorder().minX() + 16.0D, toWorldIn.getWorldBorder().maxX() - 16.0D);
              d1 = MathHelper.clamp(d1 / 8.0D, toWorldIn.getWorldBorder().minZ() + 16.0D, toWorldIn.getWorldBorder().maxZ() - 16.0D);
-@@ -597,7 +1098,7 @@
+@@ -597,7 +1104,7 @@
                  oldWorldIn.updateEntityWithOptionalForce(entityIn, false);
              }
          }
@@ -905,7 +911,7 @@
          {
              d0 = MathHelper.clamp(d0 * 8.0D, toWorldIn.getWorldBorder().minX() + 16.0D, toWorldIn.getWorldBorder().maxX() - 16.0D);
              d1 = MathHelper.clamp(d1 * 8.0D, toWorldIn.getWorldBorder().minZ() + 16.0D, toWorldIn.getWorldBorder().maxZ() - 16.0D);
-@@ -608,7 +1109,7 @@
+@@ -608,7 +1115,7 @@
                  oldWorldIn.updateEntityWithOptionalForce(entityIn, false);
              }
          }
@@ -914,7 +920,7 @@
          {
              BlockPos blockpos;
  
-@@ -634,7 +1135,7 @@
+@@ -634,7 +1141,7 @@
  
          oldWorldIn.profiler.endSection();
  
@@ -923,7 +929,7 @@
          {
              oldWorldIn.profiler.startSection("placing");
              d0 = (double)MathHelper.clamp((int)d0, -29999872, 29999872);
-@@ -643,7 +1144,8 @@
+@@ -643,7 +1150,8 @@
              if (entityIn.isEntityAlive())
              {
                  entityIn.setLocationAndAngles(d0, entityIn.posY, d1, entityIn.rotationYaw, entityIn.rotationPitch);
@@ -933,7 +939,7 @@
                  toWorldIn.spawnEntity(entityIn);
                  toWorldIn.updateEntityWithOptionalForce(entityIn, false);
              }
-@@ -654,11 +1156,155 @@
+@@ -654,11 +1162,155 @@
          entityIn.setWorld(toWorldIn);
      }
  
@@ -1090,7 +1096,7 @@
              this.playerPingIndex = 0;
          }
      }
-@@ -671,6 +1317,24 @@
+@@ -671,6 +1323,24 @@
          }
      }
  
@@ -1115,7 +1121,7 @@
      public void sendPacketToAllPlayersInDimension(Packet<?> packetIn, int dimension)
      {
          for (int i = 0; i < this.playerEntityList.size(); ++i)
-@@ -786,12 +1450,20 @@
+@@ -786,12 +1456,20 @@
          int i = this.mcServer.getOpPermissionLevel();
          this.ops.addEntry(new UserListOpsEntry(profile, this.mcServer.getOpPermissionLevel(), this.ops.bypassesPlayerLimit(profile)));
          this.sendPlayerPermissionLevel(this.getPlayerByUUID(profile.getId()), i);
@@ -1136,7 +1142,7 @@
      }
  
      private void sendPlayerPermissionLevel(EntityPlayerMP player, int permLevel)
-@@ -824,7 +1496,7 @@
+@@ -824,7 +1502,7 @@
  
      public boolean canSendCommands(GameProfile profile)
      {
@@ -1145,7 +1151,7 @@
      }
  
      @Nullable
-@@ -847,6 +1519,12 @@
+@@ -847,6 +1525,12 @@
          {
              EntityPlayerMP entityplayermp = this.playerEntityList.get(i);
  
@@ -1158,7 +1164,7 @@
              if (entityplayermp != except && entityplayermp.dimension == dimension)
              {
                  double d0 = x - entityplayermp.posX;
-@@ -905,7 +1583,7 @@
+@@ -905,7 +1589,7 @@
  
      public void updateTimeAndWeatherForPlayer(EntityPlayerMP playerIn, WorldServer worldIn)
      {
@@ -1167,7 +1173,7 @@
          playerIn.connection.sendPacket(new SPacketWorldBorder(worldborder, SPacketWorldBorder.Action.INITIALIZE));
          playerIn.connection.sendPacket(new SPacketTimeUpdate(worldIn.getTotalWorldTime(), worldIn.getWorldTime(), worldIn.getGameRules().getBoolean("doDaylightCycle")));
          BlockPos blockpos = worldIn.getSpawnPoint();
-@@ -913,16 +1591,21 @@
+@@ -913,16 +1597,21 @@
  
          if (worldIn.isRaining())
          {
@@ -1193,7 +1199,7 @@
          playerIn.connection.sendPacket(new SPacketHeldItemChange(playerIn.inventory.currentItem));
      }
  
-@@ -938,7 +1621,7 @@
+@@ -938,7 +1627,7 @@
  
      public String[] getAvailablePlayerDat()
      {
@@ -1202,7 +1208,7 @@
      }
  
      public void setWhiteListEnabled(boolean whitelistEnabled)
-@@ -1004,17 +1687,26 @@
+@@ -1004,17 +1693,26 @@
  
      public void removeAllPlayers()
      {
@@ -1233,7 +1239,7 @@
      }
  
      public void sendMessage(ITextComponent component)
-@@ -1022,6 +1714,7 @@
+@@ -1022,6 +1720,7 @@
          this.sendMessage(component, true);
      }
  
@@ -1241,7 +1247,7 @@
      public StatisticsManagerServer getPlayerStatsFile(EntityPlayer playerIn)
      {
          UUID uuid = playerIn.getUniqueID();
-@@ -1050,6 +1743,8 @@
+@@ -1050,6 +1749,8 @@
          return statisticsmanagerserver;
      }
  
@@ -1250,7 +1256,7 @@
      public PlayerAdvancements getPlayerAdvancements(EntityPlayerMP p_192054_1_)
      {
          UUID uuid = p_192054_1_.getUniqueID();
-@@ -1073,7 +1768,7 @@
+@@ -1073,7 +1774,7 @@
  
          if (this.mcServer.worlds != null)
          {

--- a/src/main/java/catserver/server/CatServerConfig.java
+++ b/src/main/java/catserver/server/CatServerConfig.java
@@ -56,6 +56,8 @@ public class CatServerConfig {
     public boolean disableAsyncCatchWarn = false;
     public boolean versionCheck = true;
 
+    public boolean callConstructCapabilityEventOnRespawn = false;
+
     public CatServerConfig(String file) {
         this.configFile = new File(file);
     }
@@ -103,6 +105,8 @@ public class CatServerConfig {
         releaseUseItemThrottle = getOrWriteIntConfig("network.packetLimit.releaseUseItemThrottle", releaseUseItemThrottle);
         disableFMLHandshake = getOrWriteBooleanConfig("network.fml.disableHandshake", config.getBoolean("disableFMLHandshake", disableFMLHandshake));
         disableFMLStatusModInfo = getOrWriteBooleanConfig("network.fml.disableStatusModInfo", config.getBoolean("disableFMLStatusModInfo", disableFMLStatusModInfo));
+        // compatibility
+        callConstructCapabilityEventOnRespawn = getOrWriteBooleanConfig("compatibility.callConstructCapabilityEventOnRespawn", callConstructCapabilityEventOnRespawn);
         // general
         disableUpdateGameProfile = getOrWriteBooleanConfig("disableUpdateGameProfile", disableUpdateGameProfile);
         disableAsyncCatchWarn = getOrWriteBooleanConfig("disableAsyncCatchWarn", disableAsyncCatchWarn);


### PR DESCRIPTION
This fixes some mechanic inconsistencies in mods like SimpleDifficulty(#536). Vanilla re-create a player instance when a player changes world, CraftBukkit made only single instance per player during its lifecycle(online period). Sadly, we can do nothing for this but call events that broken by CraftBukkit respawn logic.