### PR TITLE
Fix CB respawn logic

### DIFF
--- a/patches/net/minecraft/entity/Entity.java.patch
+++ b/patches/net/minecraft/entity/Entity.java.patch
@@ -80,7 +80,7 @@
      protected int rideCooldown;
      private Entity ridingEntity;
      public boolean forceSpawn;
-@@ -137,8 +173,8 @@
+@@ -137,18 +173,20 @@
      public float entityCollisionReduction;
      protected Random rand;
      public int ticksExisted;
@@ -91,7 +91,25 @@
      public int hurtResistantTime;
      protected boolean firstUpdate;
      protected boolean isImmuneToFire;
-@@ -172,12 +208,37 @@
+     protected EntityDataManager dataManager;
+-    protected static final DataParameter<Byte> FLAGS = EntityDataManager.<Byte>createKey(Entity.class, DataSerializers.BYTE);
+-    private static final DataParameter<Integer> AIR = EntityDataManager.<Integer>createKey(Entity.class, DataSerializers.VARINT);
+-    private static final DataParameter<String> CUSTOM_NAME = EntityDataManager.<String>createKey(Entity.class, DataSerializers.STRING);
+-    private static final DataParameter<Boolean> CUSTOM_NAME_VISIBLE = EntityDataManager.<Boolean>createKey(Entity.class, DataSerializers.BOOLEAN);
+-    private static final DataParameter<Boolean> SILENT = EntityDataManager.<Boolean>createKey(Entity.class, DataSerializers.BOOLEAN);
+-    private static final DataParameter<Boolean> NO_GRAVITY = EntityDataManager.<Boolean>createKey(Entity.class, DataSerializers.BOOLEAN);
++    public static final DataParameter<Byte> FLAGS = EntityDataManager.<Byte>createKey(Entity.class, DataSerializers.BYTE); // CatServer - protected -> public
++    // CatServer start - private -> public
++    public static final DataParameter<Integer> AIR = EntityDataManager.<Integer>createKey(Entity.class, DataSerializers.VARINT);
++    public static final DataParameter<String> CUSTOM_NAME = EntityDataManager.<String>createKey(Entity.class, DataSerializers.STRING);
++    public static final DataParameter<Boolean> CUSTOM_NAME_VISIBLE = EntityDataManager.<Boolean>createKey(Entity.class, DataSerializers.BOOLEAN);
++    public static final DataParameter<Boolean> SILENT = EntityDataManager.<Boolean>createKey(Entity.class, DataSerializers.BOOLEAN);
++    public static final DataParameter<Boolean> NO_GRAVITY = EntityDataManager.<Boolean>createKey(Entity.class, DataSerializers.BOOLEAN);
++    // CatServer end
+     public boolean addedToChunk;
+     public int chunkCoordX;
+     public int chunkCoordY;
+@@ -172,12 +210,37 @@
      protected UUID entityUniqueID;
      protected String cachedUniqueIdString;
      private final CommandResultStats cmdResultStats;
@@ -130,7 +148,7 @@
      public Entity(World worldIn)
      {
          this.entityId = nextEntityID++;
-@@ -200,8 +261,13 @@
+@@ -200,8 +263,13 @@
  
          if (worldIn != null)
          {
@@ -145,7 +163,7 @@
  
          this.dataManager = new EntityDataManager(this);
          this.dataManager.register(FLAGS, Byte.valueOf((byte)0));
-@@ -211,8 +277,18 @@
+@@ -211,8 +279,18 @@
          this.dataManager.register(SILENT, Boolean.valueOf(false));
          this.dataManager.register(NO_GRAVITY, Boolean.valueOf(false));
          this.entityInit();
@@ -164,7 +182,7 @@
      public int getEntityId()
      {
          return this.entityId;
-@@ -333,8 +409,35 @@
+@@ -333,8 +411,35 @@
          }
      }
  
@@ -201,7 +219,7 @@
          this.rotationYaw = yaw % 360.0F;
          this.rotationPitch = pitch % 360.0F;
      }
-@@ -344,6 +447,7 @@
+@@ -344,6 +449,7 @@
          this.posX = x;
          this.posY = y;
          this.posZ = z;
@@ -209,7 +227,7 @@
          float f = this.width / 2.0F;
          float f1 = this.height;
          this.setEntityBoundingBox(new AxisAlignedBB(x - (double)f, y, z - (double)f, x + (double)f, y + (double)f1, z + (double)f));
-@@ -376,6 +480,49 @@
+@@ -376,6 +482,49 @@
          this.onEntityUpdate();
      }
  
@@ -259,7 +277,7 @@
      public void onEntityUpdate()
      {
          this.world.profiler.startSection("entityBaseTick");
-@@ -396,7 +543,8 @@
+@@ -396,7 +545,8 @@
          this.prevPosZ = this.posZ;
          this.prevRotationPitch = this.rotationPitch;
          this.prevRotationYaw = this.rotationYaw;
@@ -269,7 +287,7 @@
          if (!this.world.isRemote && this.world instanceof WorldServer)
          {
              this.world.profiler.startSection("portal");
-@@ -449,7 +597,7 @@
+@@ -449,7 +599,7 @@
              this.decrementTimeUntilPortal();
              this.world.profiler.endSection();
          }
@@ -278,7 +296,7 @@
          this.spawnRunningParticles();
          this.handleWaterMovement();
  
-@@ -517,6 +665,26 @@
+@@ -517,6 +667,26 @@
          if (!this.isImmuneToFire)
          {
              this.attackEntityFrom(DamageSource.LAVA, 4.0F);
@@ -305,7 +323,7 @@
              this.setFire(15);
          }
      }
-@@ -559,6 +727,7 @@
+@@ -559,6 +729,7 @@
  
      public void move(MoverType type, double x, double y, double z)
      {
@@ -313,7 +331,7 @@
          if (this.noClip)
          {
              this.setEntityBoundingBox(this.getEntityBoundingBox().offset(x, y, z));
-@@ -566,6 +735,22 @@
+@@ -566,6 +737,22 @@
          }
          else
          {
@@ -336,7 +354,7 @@
              if (type == MoverType.PISTON)
              {
                  long i = this.world.getTotalWorldTime();
-@@ -899,6 +1084,26 @@
+@@ -899,6 +1086,26 @@
                  block.onLanded(this.world, this);
              }
  
@@ -363,7 +381,7 @@
              if (this.canTriggerWalking() && (!this.onGround || !this.isSneaking() || !(this instanceof EntityPlayer)) && !this.isRiding())
              {
                  double d15 = this.posX - d10;
-@@ -945,7 +1150,9 @@
+@@ -945,7 +1152,9 @@
                      this.nextFlap = this.playFlySound(this.distanceWalkedOnStepModified);
                  }
              }
@@ -374,7 +392,7 @@
              try
              {
                  this.doBlockCollisions();
-@@ -957,6 +1164,7 @@
+@@ -957,6 +1166,7 @@
                  this.addEntityCrashInfo(crashreportcategory);
                  throw new ReportedException(crashreport);
              }
@@ -382,7 +400,7 @@
  
              boolean flag1 = this.isWet();
  
-@@ -970,7 +1178,13 @@
+@@ -970,7 +1180,13 @@
  
                      if (this.fire == 0)
                      {
@@ -397,7 +415,7 @@
                      }
                  }
              }
-@@ -987,6 +1201,7 @@
+@@ -987,6 +1203,7 @@
  
              this.world.profiler.endSection();
          }
@@ -405,7 +423,7 @@
      }
  
      public void resetPositionToBB()
-@@ -995,6 +1210,7 @@
+@@ -995,6 +1212,7 @@
          this.posX = (axisalignedbb.minX + axisalignedbb.maxX) / 2.0D;
          this.posY = axisalignedbb.minY;
          this.posZ = (axisalignedbb.minZ + axisalignedbb.maxZ) / 2.0D;
@@ -413,7 +431,7 @@
      }
  
      protected SoundEvent getSwimSound()
-@@ -1007,6 +1223,11 @@
+@@ -1007,6 +1225,11 @@
          return SoundEvents.ENTITY_GENERIC_SPLASH;
      }
  
@@ -425,7 +443,7 @@
      protected void doBlockCollisions()
      {
          AxisAlignedBB axisalignedbb = this.getEntityBoundingBox();
-@@ -1053,7 +1274,7 @@
+@@ -1053,7 +1276,7 @@
  
      protected void playStepSound(BlockPos pos, Block blockIn)
      {
@@ -434,7 +452,7 @@
  
          if (this.world.getBlockState(pos.up()).getBlock() == Blocks.SNOW_LAYER)
          {
-@@ -1140,6 +1361,14 @@
+@@ -1140,6 +1363,14 @@
          }
      }
  
@@ -449,7 +467,7 @@
      public final boolean isImmuneToFire()
      {
          return this.isImmuneToFire;
-@@ -1259,6 +1488,7 @@
+@@ -1259,6 +1490,7 @@
          BlockPos blockpos = new BlockPos(i, j, k);
          IBlockState iblockstate = this.world.getBlockState(blockpos);
  
@@ -457,7 +475,7 @@
          if (iblockstate.getRenderType() != EnumBlockRenderType.INVISIBLE)
          {
              this.world.spawnParticle(EnumParticleTypes.BLOCK_CRACK, this.posX + ((double)this.rand.nextFloat() - 0.5D) * (double)this.width, this.getEntityBoundingBox().minY + 0.1D, this.posZ + ((double)this.rand.nextFloat() - 0.5D) * (double)this.width, -this.motionX * 4.0D, 1.5D, -this.motionZ * 4.0D, Block.getStateId(iblockstate));
-@@ -1277,12 +1507,12 @@
+@@ -1277,12 +1509,12 @@
              BlockPos blockpos = new BlockPos(this.posX, d0, this.posZ);
              IBlockState iblockstate = this.world.getBlockState(blockpos);
  
@@ -474,7 +492,7 @@
              }
              else
              {
-@@ -1354,6 +1584,11 @@
+@@ -1354,6 +1586,11 @@
  
      public void setWorld(World worldIn)
      {
@@ -486,7 +504,7 @@
          this.world = worldIn;
      }
  
-@@ -1382,6 +1617,7 @@
+@@ -1382,6 +1619,7 @@
              this.prevRotationYaw -= 360.0F;
          }
  
@@ -494,7 +512,7 @@
          this.setPosition(this.posX, this.posY, this.posZ);
          this.setRotation(yaw, pitch);
      }
-@@ -1671,6 +1907,16 @@
+@@ -1671,6 +1909,16 @@
          {
              compound.setTag("Pos", this.newDoubleNBTList(this.posX, this.posY, this.posZ));
              compound.setTag("Motion", this.newDoubleNBTList(this.motionX, this.motionY, this.motionZ));
@@ -511,7 +529,7 @@
              compound.setTag("Rotation", this.newFloatNBTList(this.rotationYaw, this.rotationPitch));
              compound.setFloat("FallDistance", this.fallDistance);
              compound.setShort("Fire", (short)this.fire);
-@@ -1680,7 +1926,14 @@
+@@ -1680,7 +1928,14 @@
              compound.setBoolean("Invulnerable", this.invulnerable);
              compound.setInteger("PortalCooldown", this.timeUntilPortal);
              compound.setUniqueId("UUID", this.getUniqueID());
@@ -527,7 +545,7 @@
              if (this.hasCustomName())
              {
                  compound.setString("CustomName", this.getCustomNameTag());
-@@ -1707,6 +1960,7 @@
+@@ -1707,6 +1962,7 @@
              {
                  compound.setBoolean("Glowing", this.glowing);
              }
@@ -535,7 +553,7 @@
  
              if (!this.tags.isEmpty())
              {
-@@ -1720,6 +1974,9 @@
+@@ -1720,6 +1976,9 @@
                  compound.setTag("Tags", nbttaglist);
              }
  
@@ -545,7 +563,7 @@
              this.writeEntityToNBT(compound);
  
              if (this.isBeingRidden())
-@@ -1764,6 +2021,7 @@
+@@ -1764,6 +2023,7 @@
              this.motionY = nbttaglist2.getDoubleAt(1);
              this.motionZ = nbttaglist2.getDoubleAt(2);
  
@@ -553,7 +571,7 @@
              if (Math.abs(this.motionX) > 10.0D)
              {
                  this.motionX = 0.0D;
-@@ -1778,6 +2036,7 @@
+@@ -1778,6 +2038,7 @@
              {
                  this.motionZ = 0.0D;
              }
@@ -561,7 +579,7 @@
  
              this.posX = nbttaglist.getDoubleAt(0);
              this.posY = nbttaglist.getDoubleAt(1);
-@@ -1826,7 +2085,11 @@
+@@ -1826,7 +2087,11 @@
              this.setSilent(compound.getBoolean("Silent"));
              this.setNoGravity(compound.getBoolean("NoGravity"));
              this.setGlowing(compound.getBoolean("Glowing"));
@@ -573,7 +591,7 @@
              if (compound.hasKey("Tags", 9))
              {
                  this.tags.clear();
-@@ -1845,6 +2108,50 @@
+@@ -1845,6 +2110,50 @@
              {
                  this.setPosition(this.posX, this.posY, this.posZ);
              }
@@ -624,7 +642,7 @@
          }
          catch (Throwable throwable)
          {
-@@ -1861,7 +2168,7 @@
+@@ -1861,7 +2170,7 @@
      }
  
      @Nullable
@@ -633,7 +651,7 @@
      {
          ResourceLocation resourcelocation = EntityList.getKey(this);
          return resourcelocation == null ? null : resourcelocation.toString();
-@@ -1918,7 +2225,10 @@
+@@ -1918,7 +2227,10 @@
          {
              EntityItem entityitem = new EntityItem(this.world, this.posX, this.posY + (double)offsetY, this.posZ, stack);
              entityitem.setDefaultPickupDelay();
@@ -645,7 +663,7 @@
              return entityitem;
          }
      }
-@@ -1985,6 +2295,7 @@
+@@ -1985,6 +2297,7 @@
              this.motionX = 0.0D;
              this.motionY = 0.0D;
              this.motionZ = 0.0D;
@@ -653,7 +671,7 @@
              this.onUpdate();
  
              if (this.isRiding())
-@@ -2032,6 +2343,7 @@
+@@ -2032,6 +2345,7 @@
              }
          }
  
@@ -661,7 +679,7 @@
          if (force || this.canBeRidden(entityIn) && entityIn.canFitPassenger(this))
          {
              if (this.isRiding())
-@@ -2067,6 +2379,7 @@
+@@ -2067,6 +2381,7 @@
          if (this.ridingEntity != null)
          {
              Entity entity = this.ridingEntity;
@@ -669,7 +687,7 @@
              this.ridingEntity = null;
              entity.removePassenger(this);
          }
-@@ -2080,6 +2393,29 @@
+@@ -2080,6 +2395,29 @@
          }
          else
          {
@@ -699,7 +717,7 @@
              if (!this.world.isRemote && passenger instanceof EntityPlayer && !(this.getControllingPassenger() instanceof EntityPlayer))
              {
                  this.riddenByEntities.add(0, passenger);
-@@ -2099,6 +2435,21 @@
+@@ -2099,6 +2437,21 @@
          }
          else
          {
@@ -721,7 +739,7 @@
              this.riddenByEntities.remove(passenger);
              passenger.rideCooldown = 60;
          }
-@@ -2167,7 +2518,7 @@
+@@ -2167,7 +2520,7 @@
          return 300;
      }
  
@@ -730,7 +748,7 @@
      public void setVelocity(double x, double y, double z)
      {
          this.motionX = x;
-@@ -2295,12 +2646,12 @@
+@@ -2295,12 +2648,12 @@
          this.setFlag(5, invisible);
      }
  
@@ -745,7 +763,7 @@
      {
          byte b0 = ((Byte)this.dataManager.get(FLAGS)).byteValue();
  
-@@ -2321,17 +2672,52 @@
+@@ -2321,17 +2674,52 @@
  
      public void setAir(int air)
      {
@@ -800,7 +818,7 @@
          }
      }
  
-@@ -2509,42 +2895,87 @@
+@@ -2509,42 +2897,87 @@
      @Nullable
      public Entity changeDimension(int dimensionIn)
      {
@@ -898,7 +916,7 @@
                  {
                      d0 = MathHelper.clamp(d0 * 8.0D, worldserver1.getWorldBorder().minX() + 16.0D, worldserver1.getWorldBorder().maxX() - 16.0D);
                      d1 = MathHelper.clamp(d1 * 8.0D, worldserver1.getWorldBorder().minZ() + 16.0D, worldserver1.getWorldBorder().maxZ() - 16.0D);
-@@ -2554,12 +2985,15 @@
+@@ -2554,12 +2987,15 @@
                  d1 = (double)MathHelper.clamp((int)d1, -29999872, 29999872);
                  float f = this.rotationYaw;
                  this.setLocationAndAngles(d0, this.posY, d1, 90.0F, 0.0F);
@@ -917,7 +935,7 @@
              this.world.profiler.endStartSection("reloading");
              Entity entity = EntityList.newEntity(this.getClass(), worldserver1);
  
-@@ -2567,7 +3001,8 @@
+@@ -2567,7 +3003,8 @@
              {
                  entity.copyDataFromOld(this);
  
@@ -927,7 +945,7 @@
                  {
                      BlockPos blockpos1 = worldserver1.getTopSolidOrLiquidBlock(worldserver1.getSpawnPoint());
                      entity.moveToBlockPosAndAngles(blockpos1, entity.rotationYaw, entity.rotationPitch);
-@@ -2576,19 +3011,28 @@
+@@ -2576,19 +3013,28 @@
                  {
                      entity.moveToBlockPosAndAngles(blockpos, entity.rotationYaw, entity.rotationPitch);
                  }
@@ -957,7 +975,7 @@
              return entity;
          }
          else
-@@ -2604,7 +3048,7 @@
+@@ -2604,7 +3050,7 @@
  
      public float getExplosionResistance(Explosion explosionIn, World worldIn, BlockPos pos, IBlockState blockStateIn)
      {
@@ -966,7 +984,7 @@
      }
  
      public boolean canExplosionDestroyBlock(Explosion explosionIn, World worldIn, BlockPos pos, IBlockState blockStateIn, float p_174816_5_)
-@@ -2717,6 +3161,11 @@
+@@ -2717,6 +3163,11 @@
  
      public void setCustomNameTag(String name)
      {
@@ -978,7 +996,7 @@
          this.dataManager.set(CUSTOM_NAME, name);
      }
  
-@@ -2800,7 +3249,26 @@
+@@ -2800,7 +3251,26 @@
  
      public void setEntityBoundingBox(AxisAlignedBB bb)
      {
@@ -1006,7 +1024,7 @@
      }
  
      public float getEyeHeight()
-@@ -2901,6 +3369,218 @@
+@@ -2901,6 +3371,218 @@
          EnchantmentHelper.applyArthropodEnchantments(entityLivingBaseIn, entityIn);
      }
  
@@ -1225,7 +1243,7 @@
      public void addTrackingPlayer(EntityPlayerMP player)
      {
      }
-@@ -3069,7 +3749,7 @@
+@@ -3069,7 +3751,7 @@
          return SoundCategory.NEUTRAL;
      }
  

--- a/patches/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/net/minecraft/entity/EntityLivingBase.java.patch
@@ -40,7 +40,7 @@
  import net.minecraft.nbt.NBTTagList;
  import net.minecraft.network.datasync.DataParameter;
  import net.minecraft.network.datasync.DataSerializers;
-@@ -76,20 +86,33 @@
+@@ -76,20 +86,35 @@
  import net.minecraftforge.fml.relauncher.SideOnly;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
@@ -62,13 +62,19 @@
      private static final Logger LOGGER = LogManager.getLogger();
      private static final UUID SPRINTING_SPEED_BOOST_ID = UUID.fromString("662A6B8D-DA3E-4C1C-8813-96EA6097278D");
      private static final AttributeModifier SPRINTING_SPEED_BOOST = (new AttributeModifier(SPRINTING_SPEED_BOOST_ID, "Sprinting speed boost", 0.30000001192092896D, 2)).setSaved(false);
-+    public static final net.minecraft.entity.ai.attributes.IAttribute SWIM_SPEED = new net.minecraft.entity.ai.attributes.RangedAttribute(null, "forge.swimSpeed", 1.0D, 0.0D, 1024.0D).setShouldWatch(true);
-     protected static final DataParameter<Byte> HAND_STATES = EntityDataManager.<Byte>createKey(EntityLivingBase.class, DataSerializers.BYTE);
+-    protected static final DataParameter<Byte> HAND_STATES = EntityDataManager.<Byte>createKey(EntityLivingBase.class, DataSerializers.BYTE);
 -    private static final DataParameter<Float> HEALTH = EntityDataManager.<Float>createKey(EntityLivingBase.class, DataSerializers.FLOAT);
+-    private static final DataParameter<Integer> POTION_EFFECTS = EntityDataManager.<Integer>createKey(EntityLivingBase.class, DataSerializers.VARINT);
+-    private static final DataParameter<Boolean> HIDE_PARTICLES = EntityDataManager.<Boolean>createKey(EntityLivingBase.class, DataSerializers.BOOLEAN);
+-    private static final DataParameter<Integer> ARROW_COUNT_IN_ENTITY = EntityDataManager.<Integer>createKey(EntityLivingBase.class, DataSerializers.VARINT);
++    public static final net.minecraft.entity.ai.attributes.IAttribute SWIM_SPEED = new net.minecraft.entity.ai.attributes.RangedAttribute(null, "forge.swimSpeed", 1.0D, 0.0D, 1024.0D).setShouldWatch(true);
++    public static final DataParameter<Byte> HAND_STATES = EntityDataManager.<Byte>createKey(EntityLivingBase.class, DataSerializers.BYTE); // CatServer - protected -> public
 +    public static final DataParameter<Float> HEALTH = EntityDataManager.<Float>createKey(EntityLivingBase.class, DataSerializers.FLOAT);
-     private static final DataParameter<Integer> POTION_EFFECTS = EntityDataManager.<Integer>createKey(EntityLivingBase.class, DataSerializers.VARINT);
-     private static final DataParameter<Boolean> HIDE_PARTICLES = EntityDataManager.<Boolean>createKey(EntityLivingBase.class, DataSerializers.BOOLEAN);
-     private static final DataParameter<Integer> ARROW_COUNT_IN_ENTITY = EntityDataManager.<Integer>createKey(EntityLivingBase.class, DataSerializers.VARINT);
++    // CatServer start - private -> public
++    public static final DataParameter<Integer> POTION_EFFECTS = EntityDataManager.<Integer>createKey(EntityLivingBase.class, DataSerializers.VARINT);
++    public static final DataParameter<Boolean> HIDE_PARTICLES = EntityDataManager.<Boolean>createKey(EntityLivingBase.class, DataSerializers.BOOLEAN);
++    public static final DataParameter<Integer> ARROW_COUNT_IN_ENTITY = EntityDataManager.<Integer>createKey(EntityLivingBase.class, DataSerializers.VARINT);
++    // CatServer end - private -> public
      private AbstractAttributeMap attributeMap;
 -    private final CombatTracker _combatTracker = new CombatTracker(this);
 -    private final Map<Potion, PotionEffect> activePotionsMap = Maps.<Potion, PotionEffect>newHashMap();
@@ -77,7 +83,7 @@
      private final NonNullList<ItemStack> handInventory = NonNullList.<ItemStack>withSize(2, ItemStack.EMPTY);
      private final NonNullList<ItemStack> armorArray = NonNullList.<ItemStack>withSize(4, ItemStack.EMPTY);
      public boolean isSwingInProgress;
-@@ -116,7 +139,7 @@
+@@ -116,7 +141,7 @@
      public float rotationYawHead;
      public float prevRotationYawHead;
      public float jumpMovementFactor = 0.02F;
@@ -86,7 +92,7 @@
      protected int recentlyHit;
      protected boolean dead;
      protected int idleTime;
-@@ -126,7 +149,7 @@
+@@ -126,7 +151,7 @@
      protected float prevMovedDistance;
      protected float unused180;
      protected int scoreValue;
@@ -95,7 +101,7 @@
      protected boolean isJumping;
      public float moveStrafing;
      public float moveVertical;
-@@ -138,9 +161,9 @@
+@@ -138,9 +163,9 @@
      protected double interpTargetZ;
      protected double interpTargetYaw;
      protected double interpTargetPitch;
@@ -108,7 +114,7 @@
      private EntityLivingBase lastAttackedEntity;
      private int lastAttackedEntityTime;
      private float landMovementFactor;
-@@ -153,6 +176,21 @@
+@@ -153,6 +178,21 @@
      private DamageSource lastDamageSource;
      private long lastDamageStamp;
  
@@ -130,7 +136,7 @@
      public void onKillCommand()
      {
          this.attackEntityFrom(DamageSource.OUT_OF_WORLD, Float.MAX_VALUE);
-@@ -162,7 +200,9 @@
+@@ -162,7 +202,9 @@
      {
          super(worldIn);
          this.applyEntityAttributes();
@@ -141,7 +147,7 @@
          this.preventEntitySpawning = true;
          this.randomUnused1 = (float)((Math.random() + 1.0D) * 0.009999999776482582D);
          this.setPosition(this.posX, this.posY, this.posZ);
-@@ -188,6 +228,7 @@
+@@ -188,6 +230,7 @@
          this.getAttributeMap().registerAttribute(SharedMonsterAttributes.MOVEMENT_SPEED);
          this.getAttributeMap().registerAttribute(SharedMonsterAttributes.ARMOR);
          this.getAttributeMap().registerAttribute(SharedMonsterAttributes.ARMOR_TOUGHNESS);
@@ -149,7 +155,7 @@
      }
  
      protected void updateFallState(double y, boolean onGroundIn, IBlockState state, BlockPos pos)
-@@ -201,11 +242,21 @@
+@@ -201,11 +244,21 @@
          {
              float f = (float)MathHelper.ceil(this.fallDistance - 3.0F);
  
@@ -173,7 +179,7 @@
              }
          }
  
-@@ -257,7 +308,12 @@
+@@ -257,7 +310,12 @@
          {
              if (!this.isInsideOfMaterial(Material.WATER))
              {
@@ -187,7 +193,7 @@
              }
              else
              {
-@@ -281,7 +337,7 @@
+@@ -281,7 +339,7 @@
                      }
                  }
  
@@ -196,7 +202,7 @@
                  {
                      this.dismountRidingEntity();
                  }
-@@ -356,6 +412,16 @@
+@@ -356,6 +414,16 @@
          this.world.profiler.endSection();
      }
  
@@ -213,7 +219,7 @@
      protected void frostWalk(BlockPos pos)
      {
          int i = EnchantmentHelper.getMaxEnchantmentLevel(Enchantments.FROST_WALKER, this);
-@@ -375,19 +441,18 @@
+@@ -375,19 +443,18 @@
      {
          ++this.deathTime;
  
@@ -238,7 +244,7 @@
  
              this.setDead();
  
-@@ -563,6 +628,15 @@
+@@ -563,6 +630,15 @@
              }
          }
  
@@ -254,7 +260,7 @@
          if (compound.hasKey("Health", 99))
          {
              this.setHealth(compound.getFloat("Health"));
-@@ -589,10 +663,13 @@
+@@ -589,10 +665,13 @@
          }
      }
  
@@ -269,7 +275,7 @@
          try
          {
              while (iterator.hasNext())
-@@ -602,7 +679,7 @@
+@@ -602,7 +681,7 @@
  
                  if (!potioneffect.onUpdate(this))
                  {
@@ -278,7 +284,7 @@
                      {
                          iterator.remove();
                          this.onFinishedPotionEffect(potioneffect);
-@@ -619,6 +696,16 @@
+@@ -619,6 +698,16 @@
              ;
          }
  
@@ -295,7 +301,7 @@
          if (this.potionsNeedUpdate)
          {
              if (!this.world.isRemote)
-@@ -670,8 +757,10 @@
+@@ -670,8 +759,10 @@
          else
          {
              Collection<PotionEffect> collection = this.activePotionsMap.values();
@@ -308,7 +314,7 @@
              this.setInvisible(this.isPotionActive(MobEffects.INVISIBILITY));
          }
      }
-@@ -703,7 +792,10 @@
+@@ -703,7 +794,10 @@
  
              while (iterator.hasNext())
              {
@@ -320,7 +326,7 @@
                  iterator.remove();
              }
          }
-@@ -732,10 +824,15 @@
+@@ -732,10 +826,15 @@
  
      public void addPotionEffect(PotionEffect potioneffectIn)
      {
@@ -336,7 +342,7 @@
              if (potioneffect == null)
              {
                  this.activePotionsMap.put(potioneffectIn.getPotion(), potioneffectIn);
-@@ -751,6 +848,9 @@
+@@ -751,6 +850,9 @@
  
      public boolean isPotionApplicable(PotionEffect potioneffectIn)
      {
@@ -346,7 +352,7 @@
          if (this.getCreatureAttribute() == EnumCreatureAttribute.UNDEAD)
          {
              Potion potion = potioneffectIn.getPotion();
-@@ -772,11 +872,16 @@
+@@ -772,11 +874,16 @@
      @Nullable
      public PotionEffect removeActivePotionEffect(@Nullable Potion potioneffectin)
      {
@@ -363,7 +369,7 @@
          PotionEffect potioneffect = this.removeActivePotionEffect(potionIn);
  
          if (potioneffect != null)
-@@ -817,28 +922,63 @@
+@@ -817,28 +924,63 @@
          }
      }
  
@@ -428,7 +434,7 @@
          if (this.isEntityInvulnerable(source))
          {
              return false;
-@@ -863,15 +1003,17 @@
+@@ -863,15 +1005,17 @@
              {
                  float f = amount;
  
@@ -449,7 +455,7 @@
                  {
                      this.damageShield(amount);
                      amount = 0.0F;
-@@ -896,22 +1038,38 @@
+@@ -896,22 +1040,38 @@
                  {
                      if (amount <= this.lastDamage)
                      {
@@ -490,7 +496,7 @@
                  this.attackedAtYaw = 0.0F;
                  Entity entity1 = source.getTrueSource();
  
-@@ -927,9 +1085,9 @@
+@@ -927,9 +1087,9 @@
                          this.recentlyHit = 100;
                          this.attackingPlayer = (EntityPlayer)entity1;
                      }
@@ -502,7 +508,7 @@
  
                          if (entitywolf.isTamed())
                          {
-@@ -1049,22 +1207,28 @@
+@@ -1049,22 +1209,28 @@
          else
          {
              ItemStack itemstack = null;
@@ -537,7 +543,7 @@
                  {
                      EntityPlayerMP entityplayermp = (EntityPlayerMP)this;
                      entityplayermp.addStat(StatList.getObjectUseStats(Items.TOTEM_OF_UNDYING));
-@@ -1078,7 +1242,8 @@
+@@ -1078,7 +1244,8 @@
                  this.world.setEntityState(this, (byte)35);
              }
  
@@ -547,7 +553,7 @@
          }
      }
  
-@@ -1127,7 +1292,7 @@
+@@ -1127,7 +1294,7 @@
  
      public void renderBrokenItemStack(ItemStack stack)
      {
@@ -556,7 +562,7 @@
  
          for (int i = 0; i < 5; ++i)
          {
-@@ -1139,12 +1304,17 @@
+@@ -1139,12 +1306,17 @@
              vec3d1 = vec3d1.rotatePitch(-this.rotationPitch * 0.017453292F);
              vec3d1 = vec3d1.rotateYaw(-this.rotationYaw * 0.017453292F);
              vec3d1 = vec3d1.addVector(this.posX, this.posY + (double)this.getEyeHeight(), this.posZ);
@@ -575,7 +581,7 @@
          if (!this.dead)
          {
              Entity entity = cause.getTrueSource();
-@@ -1165,18 +1335,42 @@
+@@ -1165,18 +1337,42 @@
  
              if (!this.world.isRemote)
              {
@@ -623,7 +629,7 @@
              }
  
              this.world.setEntityState(this, (byte)3);
-@@ -1195,6 +1389,9 @@
+@@ -1195,6 +1391,9 @@
  
      public void knockBack(Entity entityIn, float strength, double xRatio, double zRatio)
      {
@@ -633,7 +639,7 @@
          if (this.rand.nextDouble() >= this.getEntityAttribute(SharedMonsterAttributes.KNOCKBACK_RESISTANCE).getAttributeValue())
          {
              this.isAirBorne = true;
-@@ -1253,15 +1450,7 @@
+@@ -1253,15 +1452,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.world.getBlockState(blockpos);
              Block block = iblockstate.getBlock();
@@ -650,7 +656,7 @@
          }
      }
  
-@@ -1287,6 +1476,9 @@
+@@ -1287,6 +1478,9 @@
  
      public void fall(float distance, float damageMultiplier)
      {
@@ -660,7 +666,7 @@
          super.fall(distance, damageMultiplier);
          PotionEffect potioneffect = this.getActivePotionEffect(MobEffects.JUMP_BOOST);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.getAmplifier() + 1);
-@@ -1294,8 +1486,11 @@
+@@ -1294,8 +1488,11 @@
  
          if (i > 0)
          {
@@ -673,7 +679,7 @@
              int j = MathHelper.floor(this.posX);
              int k = MathHelper.floor(this.posY - 0.20000000298023224D);
              int l = MathHelper.floor(this.posZ);
-@@ -1303,7 +1498,7 @@
+@@ -1303,7 +1500,7 @@
  
              if (iblockstate.getMaterial() != Material.AIR)
              {
@@ -682,7 +688,7 @@
                  this.playSound(soundtype.getFallSound(), soundtype.getVolume() * 0.5F, soundtype.getPitch() * 0.75F);
              }
          }
-@@ -1335,7 +1530,7 @@
+@@ -1335,7 +1532,7 @@
      {
          if (!source.isUnblockable())
          {
@@ -691,7 +697,7 @@
              damage = CombatRules.getDamageAfterAbsorb(damage, (float)this.getTotalArmorValue(), (float)this.getEntityAttribute(SharedMonsterAttributes.ARMOR_TOUGHNESS).getAttributeValue());
          }
  
-@@ -1350,7 +1545,8 @@
+@@ -1350,7 +1547,8 @@
          }
          else
          {
@@ -701,7 +707,7 @@
              {
                  int i = (this.getActivePotionEffect(MobEffects.RESISTANCE).getAmplifier() + 1) * 5;
                  int j = 25 - i;
-@@ -1378,24 +1574,191 @@
+@@ -1378,24 +1576,191 @@
  
      protected void damageEntity(DamageSource damageSrc, float damageAmount)
      {
@@ -894,7 +900,7 @@
      public CombatTracker getCombatTracker()
      {
          return this._combatTracker;
-@@ -1447,6 +1810,11 @@
+@@ -1447,6 +1812,11 @@
  
      public void swingArm(EnumHand hand)
      {
@@ -906,7 +912,7 @@
          if (!this.isSwingInProgress || this.swingProgressInt >= this.getArmSwingAnimationEnd() / 2 || this.swingProgressInt < 0)
          {
              this.swingProgressInt = -1;
-@@ -1570,6 +1938,7 @@
+@@ -1570,6 +1940,7 @@
          if (this.attributeMap == null)
          {
              this.attributeMap = new AttributeMap();
@@ -914,7 +920,7 @@
          }
  
          return this.attributeMap;
-@@ -1694,7 +2063,7 @@
+@@ -1694,7 +2065,7 @@
  
                      if (!this.world.collidesWithAnyBlock(axisalignedbb1))
                      {
@@ -923,7 +929,7 @@
                          {
                              this.setPositionAndUpdate(d11, this.posY + 1.0D, d12);
                              return;
-@@ -1702,14 +2071,14 @@
+@@ -1702,14 +2073,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.posY - 1.0D, d12);
  
@@ -940,7 +946,7 @@
                      {
                          d1 = d11;
                          d13 = this.posY + 2.0D;
-@@ -1781,16 +2150,17 @@
+@@ -1781,16 +2152,17 @@
          }
  
          this.isAirBorne = true;
@@ -960,7 +966,7 @@
      }
  
      protected float getWaterSlowDown()
-@@ -1864,7 +2234,8 @@
+@@ -1864,7 +2236,8 @@
  
                          if (this.onGround && !this.world.isRemote)
                          {
@@ -970,7 +976,7 @@
                          }
                      }
                      else
-@@ -1874,7 +2245,8 @@
+@@ -1874,7 +2247,8 @@
  
                          if (this.onGround)
                          {
@@ -980,7 +986,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +2266,8 @@
+@@ -1894,7 +2268,8 @@
  
                          if (this.onGround)
                          {
@@ -990,7 +996,7 @@
                          }
  
                          if (this.isOnLadder())
-@@ -2054,6 +2427,8 @@
+@@ -2054,6 +2429,8 @@
  
      public void onUpdate()
      {
@@ -999,7 +1005,7 @@
          super.onUpdate();
          this.updateActiveHand();
  
-@@ -2096,7 +2471,9 @@
+@@ -2096,7 +2473,9 @@
  
                  if (!ItemStack.areItemStacksEqual(itemstack1, itemstack))
                  {
@@ -1009,7 +1015,7 @@
  
                      if (!itemstack.isEmpty())
                      {
-@@ -2135,7 +2512,9 @@
+@@ -2135,7 +2514,9 @@
              }
          }
  
@@ -1019,7 +1025,7 @@
          double d0 = this.posX - this.prevPosX;
          double d1 = this.posZ - this.prevPosZ;
          float f3 = (float)(d0 * d0 + d1 * d1);
-@@ -2228,6 +2607,7 @@
+@@ -2228,6 +2609,7 @@
          {
              this.ticksElytraFlying = 0;
          }
@@ -1027,7 +1033,7 @@
      }
  
      protected float updateDistance(float p_110146_1_, float p_110146_2_)
-@@ -2304,7 +2684,7 @@
+@@ -2304,7 +2686,7 @@
          }
  
          this.world.profiler.startSection("ai");
@@ -1036,7 +1042,7 @@
          if (this.isMovementBlocked())
          {
              this.isJumping = false;
-@@ -2318,6 +2698,7 @@
+@@ -2318,6 +2700,7 @@
              this.updateEntityActionState();
              this.world.profiler.endSection();
          }
@@ -1044,7 +1050,7 @@
  
          this.world.profiler.endSection();
          this.world.profiler.startSection("jump");
-@@ -2349,10 +2730,14 @@
+@@ -2349,10 +2732,14 @@
          this.moveForward *= 0.98F;
          this.randomYawVelocity *= 0.9F;
          this.updateElytra();
@@ -1059,7 +1065,7 @@
          this.world.profiler.endSection();
      }
  
-@@ -2385,7 +2770,8 @@
+@@ -2385,7 +2772,8 @@
  
          if (!this.world.isRemote)
          {
@@ -1069,7 +1075,7 @@
          }
      }
  
-@@ -2419,9 +2805,13 @@
+@@ -2419,9 +2807,13 @@
                  }
              }
  
@@ -1084,7 +1090,7 @@
                  this.collideWithEntity(entity);
              }
          }
-@@ -2519,12 +2909,12 @@
+@@ -2519,12 +2911,12 @@
  
      public boolean canBeCollidedWith()
      {
@@ -1099,7 +1105,7 @@
      }
  
      protected void markVelocityChanged()
-@@ -2575,6 +2965,40 @@
+@@ -2575,6 +2967,40 @@
          this.potionsNeedUpdate = true;
      }
  
@@ -1140,7 +1146,7 @@
      public abstract EnumHandSide getPrimaryHand();
  
      public boolean isHandActive()
-@@ -2592,15 +3016,23 @@
+@@ -2592,15 +3018,23 @@
          if (this.isHandActive())
          {
              ItemStack itemstack = this.getHeldItem(this.getActiveHand());
@@ -1165,7 +1171,7 @@
                  {
                      this.onItemUseFinish();
                  }
-@@ -2618,8 +3050,10 @@
+@@ -2618,8 +3052,10 @@
  
          if (!itemstack.isEmpty() && !this.isHandActive())
          {
@@ -1177,7 +1183,7 @@
  
              if (!this.world.isRemote)
              {
-@@ -2700,7 +3134,27 @@
+@@ -2700,7 +3136,27 @@
          if (!this.activeItemStack.isEmpty() && this.isHandActive())
          {
              this.updateItemUse(this.activeItemStack, 16);
@@ -1206,7 +1212,7 @@
              this.resetActiveHand();
          }
      }
-@@ -2724,7 +3178,8 @@
+@@ -2724,7 +3180,8 @@
      {
          if (!this.activeItemStack.isEmpty())
          {
@@ -1216,7 +1222,7 @@
          }
  
          this.resetActiveHand();
-@@ -2808,11 +3263,14 @@
+@@ -2808,11 +3265,14 @@
  
              if (flag1)
              {
@@ -1236,7 +1242,7 @@
                  }
              }
          }
-@@ -2847,11 +3305,41 @@
+@@ -2847,11 +3307,41 @@
          }
      }
  
@@ -1278,7 +1284,7 @@
      public boolean attackable()
      {
          return true;
-@@ -2861,4 +3349,30 @@
+@@ -2861,4 +3351,30 @@
      public void setPartying(BlockPos pos, boolean p_191987_2_)
      {
      }

--- a/patches/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -31,7 +31,7 @@
  import net.minecraft.item.ItemElytra;
  import net.minecraft.item.ItemStack;
  import net.minecraft.item.ItemSword;
-@@ -92,10 +90,26 @@
+@@ -92,21 +90,41 @@
  import net.minecraft.world.WorldServer;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
@@ -50,18 +50,28 @@
 -public abstract class EntityPlayer extends EntityLivingBase
 +public abstract class EntityPlayer extends EntityLivingBase implements ASMFixer.IEntityPlayerASMFixer
  {
+-    private static final DataParameter<Float> ABSORPTION = EntityDataManager.<Float>createKey(EntityPlayer.class, DataSerializers.FLOAT);
+-    private static final DataParameter<Integer> PLAYER_SCORE = EntityDataManager.<Integer>createKey(EntityPlayer.class, DataSerializers.VARINT);
+-    protected static final DataParameter<Byte> PLAYER_MODEL_FLAG = EntityDataManager.<Byte>createKey(EntityPlayer.class, DataSerializers.BYTE);
+-    protected static final DataParameter<Byte> MAIN_HAND = EntityDataManager.<Byte>createKey(EntityPlayer.class, DataSerializers.BYTE);
+-    protected static final DataParameter<NBTTagCompound> LEFT_SHOULDER_ENTITY = EntityDataManager.<NBTTagCompound>createKey(EntityPlayer.class, DataSerializers.COMPOUND_TAG);
+-    protected static final DataParameter<NBTTagCompound> RIGHT_SHOULDER_ENTITY = EntityDataManager.<NBTTagCompound>createKey(EntityPlayer.class, DataSerializers.COMPOUND_TAG);
 +    public static final String PERSISTED_NBT_TAG = "PlayerPersisted";
 +    protected java.util.HashMap<Integer, BlockPos> spawnChunkMap = new java.util.HashMap<Integer, BlockPos>();
 +    protected java.util.HashMap<Integer, Boolean> spawnForcedMap = new java.util.HashMap<Integer, Boolean>();
 +    public float eyeHeight = this.getDefaultEyeHeight();
 +    public static final net.minecraft.entity.ai.attributes.IAttribute REACH_DISTANCE = new net.minecraft.entity.ai.attributes.RangedAttribute(null, "generic.reachDistance", 5.0D, 0.0D, 1024.0D).setShouldWatch(true);
 +
-     private static final DataParameter<Float> ABSORPTION = EntityDataManager.<Float>createKey(EntityPlayer.class, DataSerializers.FLOAT);
-     private static final DataParameter<Integer> PLAYER_SCORE = EntityDataManager.<Integer>createKey(EntityPlayer.class, DataSerializers.VARINT);
-     protected static final DataParameter<Byte> PLAYER_MODEL_FLAG = EntityDataManager.<Byte>createKey(EntityPlayer.class, DataSerializers.BYTE);
-@@ -103,10 +117,10 @@
-     protected static final DataParameter<NBTTagCompound> LEFT_SHOULDER_ENTITY = EntityDataManager.<NBTTagCompound>createKey(EntityPlayer.class, DataSerializers.COMPOUND_TAG);
-     protected static final DataParameter<NBTTagCompound> RIGHT_SHOULDER_ENTITY = EntityDataManager.<NBTTagCompound>createKey(EntityPlayer.class, DataSerializers.COMPOUND_TAG);
++    // CatServer start - private -> public
++    public static final DataParameter<Float> ABSORPTION = EntityDataManager.<Float>createKey(EntityPlayer.class, DataSerializers.FLOAT);
++    public static final DataParameter<Integer> PLAYER_SCORE = EntityDataManager.<Integer>createKey(EntityPlayer.class, DataSerializers.VARINT);
++    // CatServer end - private -> public
++    // CatServer start - protected -> public
++    public static final DataParameter<Byte> PLAYER_MODEL_FLAG = EntityDataManager.<Byte>createKey(EntityPlayer.class, DataSerializers.BYTE);
++    public static final DataParameter<Byte> MAIN_HAND = EntityDataManager.<Byte>createKey(EntityPlayer.class, DataSerializers.BYTE);
++    public static final DataParameter<NBTTagCompound> LEFT_SHOULDER_ENTITY = EntityDataManager.<NBTTagCompound>createKey(EntityPlayer.class, DataSerializers.COMPOUND_TAG);
++    public static final DataParameter<NBTTagCompound> RIGHT_SHOULDER_ENTITY = EntityDataManager.<NBTTagCompound>createKey(EntityPlayer.class, DataSerializers.COMPOUND_TAG);
++    // CatServer end
      public InventoryPlayer inventory = new InventoryPlayer(this);
 -    protected InventoryEnderChest enderChest = new InventoryEnderChest();
 +    protected InventoryEnderChest enderChest = new InventoryEnderChest(this); // CraftBukkit - add "this" to constructor
@@ -72,7 +82,7 @@
      protected int flyToggleTimer;
      public float prevCameraYaw;
      public float cameraYaw;
-@@ -117,9 +131,9 @@
+@@ -117,9 +135,9 @@
      public double chasingPosX;
      public double chasingPosY;
      public double chasingPosZ;
@@ -84,7 +94,7 @@
      public float renderOffsetX;
      @SideOnly(Side.CLIENT)
      public float renderOffsetY;
-@@ -141,6 +155,10 @@
+@@ -141,6 +159,10 @@
      @Nullable
      public EntityFishHook fishEntity;
  
@@ -95,7 +105,7 @@
      protected CooldownTracker createCooldownTracker()
      {
          return new CooldownTracker();
-@@ -156,6 +174,9 @@
+@@ -156,6 +178,9 @@
          BlockPos blockpos = worldIn.getSpawnPoint();
          this.setLocationAndAngles((double)blockpos.getX() + 0.5D, (double)(blockpos.getY() + 1), (double)blockpos.getZ() + 0.5D, 0.0F, 0.0F);
          this.unused180 = 180.0F;
@@ -105,7 +115,7 @@
      }
  
      protected void applyEntityAttributes()
-@@ -165,6 +186,7 @@
+@@ -165,6 +190,7 @@
          this.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).setBaseValue(0.10000000149011612D);
          this.getAttributeMap().registerAttribute(SharedMonsterAttributes.ATTACK_SPEED);
          this.getAttributeMap().registerAttribute(SharedMonsterAttributes.LUCK);
@@ -113,7 +123,7 @@
      }
  
      protected void entityInit()
-@@ -180,6 +202,7 @@
+@@ -180,6 +206,7 @@
  
      public void onUpdate()
      {
@@ -121,7 +131,7 @@
          this.noClip = this.isSpectator();
  
          if (this.isSpectator())
-@@ -207,7 +230,7 @@
+@@ -207,7 +234,7 @@
                  {
                      this.wakeUpPlayer(true, true, false);
                  }
@@ -130,7 +140,7 @@
                  {
                      this.wakeUpPlayer(false, true, true);
                  }
-@@ -367,6 +390,7 @@
+@@ -367,6 +394,7 @@
                  this.setSize(f, f1);
              }
          }
@@ -138,7 +148,7 @@
      }
  
      public int getMaxInPortalTime()
-@@ -399,7 +423,7 @@
+@@ -399,7 +427,7 @@
          return SoundCategory.PLAYERS;
      }
  
@@ -147,7 +157,7 @@
      {
          return 20;
      }
-@@ -454,11 +478,11 @@
+@@ -454,11 +482,11 @@
              this.cameraYaw = 0.0F;
              this.addMountedMovementStat(this.posX - d0, this.posY - d1, this.posZ - d2);
  
@@ -161,7 +171,7 @@
              }
          }
      }
-@@ -490,7 +514,8 @@
+@@ -490,7 +518,8 @@
          {
              if (this.getHealth() < this.getMaxHealth() && this.ticksExisted % 20 == 0)
              {
@@ -171,7 +181,7 @@
              }
  
              if (this.foodStats.needFood() && this.ticksExisted % 10 == 0)
-@@ -518,7 +543,7 @@
+@@ -518,7 +547,7 @@
  
          this.setAIMoveSpeed((float)iattributeinstance.getAttributeValue());
          float f = MathHelper.sqrt(this.motionX * this.motionX + this.motionZ * this.motionZ);
@@ -180,7 +190,7 @@
  
          if (f > 0.1F)
          {
-@@ -609,11 +634,15 @@
+@@ -609,11 +638,15 @@
  
      public void onDeath(DamageSource cause)
      {
@@ -196,7 +206,7 @@
          if ("Notch".equals(this.getName()))
          {
              this.dropItem(new ItemStack(Items.APPLE, 1), true, false);
-@@ -625,6 +654,9 @@
+@@ -625,6 +658,9 @@
              this.inventory.dropAllItems();
          }
  
@@ -206,7 +216,7 @@
          if (cause != null)
          {
              this.motionX = (double)(-MathHelper.cos((this.attackedAtYaw + this.rotationYaw) * 0.017453292F) * 0.1F);
-@@ -675,13 +707,25 @@
+@@ -675,13 +711,25 @@
      @Nullable
      public EntityItem dropItem(boolean dropAll)
      {
@@ -234,7 +244,7 @@
      }
  
      @Nullable
-@@ -723,6 +767,30 @@
+@@ -723,6 +771,30 @@
                  entityitem.motionZ += Math.sin((double)f3) * (double)f2;
              }
  
@@ -265,7 +275,7 @@
              ItemStack itemstack = this.dropItemAndGetStack(entityitem);
  
              if (traceItem)
-@@ -741,12 +809,20 @@
+@@ -741,12 +813,20 @@
  
      public ItemStack dropItemAndGetStack(EntityItem p_184816_1_)
      {
@@ -286,7 +296,7 @@
          float f = this.inventory.getDestroySpeed(state);
  
          if (f > 1.0F)
-@@ -798,12 +874,13 @@
+@@ -798,12 +878,13 @@
              f /= 5.0F;
          }
  
@@ -302,7 +312,7 @@
      }
  
      public static void registerFixesPlayer(DataFixer fixer)
-@@ -857,12 +934,28 @@
+@@ -857,12 +938,28 @@
              this.wakeUpPlayer(true, true, false);
          }
  
@@ -331,7 +341,7 @@
          this.foodStats.readNBT(compound);
          this.capabilities.readCapabilitiesFromNBT(compound);
  
-@@ -896,6 +989,7 @@
+@@ -896,6 +993,7 @@
          compound.setInteger("XpTotal", this.experienceTotal);
          compound.setInteger("XpSeed", this.xpSeed);
          compound.setInteger("Score", this.getScore());
@@ -339,7 +349,7 @@
  
          if (this.spawnPos != null)
          {
-@@ -905,6 +999,27 @@
+@@ -905,6 +1003,27 @@
              compound.setBoolean("SpawnForced", this.spawnForced);
          }
  
@@ -367,7 +377,7 @@
          this.foodStats.writeNBT(compound);
          this.capabilities.writeCapabilitiesToNBT(compound);
          compound.setTag("EnderItems", this.enderChest.saveInventoryToNBT());
-@@ -918,10 +1033,12 @@
+@@ -918,10 +1037,12 @@
          {
              compound.setTag("ShoulderEntityRight", this.getRightShoulderEntity());
          }
@@ -380,7 +390,7 @@
          if (this.isEntityInvulnerable(source))
          {
              return false;
-@@ -945,13 +1062,13 @@
+@@ -945,13 +1066,13 @@
                      this.wakeUpPlayer(true, true, false);
                  }
  
@@ -396,7 +406,7 @@
                      }
  
                      if (this.world.getDifficulty() == EnumDifficulty.EASY)
-@@ -965,7 +1082,14 @@
+@@ -965,7 +1086,14 @@
                      }
                  }
  
@@ -412,7 +422,7 @@
              }
          }
      }
-@@ -974,7 +1098,7 @@
+@@ -974,7 +1102,7 @@
      {
          super.blockUsingShield(p_190629_1_);
  
@@ -421,7 +431,7 @@
          {
              this.disableShield(true);
          }
-@@ -982,17 +1106,29 @@
+@@ -982,17 +1110,29 @@
  
      public boolean canAttackPlayer(EntityPlayer other)
      {
@@ -460,7 +470,7 @@
      }
  
      protected void damageArmor(float damage)
-@@ -1002,14 +1138,16 @@
+@@ -1002,14 +1142,16 @@
  
      protected void damageShield(float damage)
      {
@@ -478,7 +488,7 @@
  
                  if (enumhand == EnumHand.MAIN_HAND)
                  {
-@@ -1043,13 +1181,27 @@
+@@ -1043,13 +1185,27 @@
  
      protected void damageEntity(DamageSource damageSrc, float damageAmount)
      {
@@ -507,7 +517,7 @@
  
              if (damageAmount != 0.0F)
              {
-@@ -1064,6 +1216,7 @@
+@@ -1064,6 +1220,7 @@
                  }
              }
          }
@@ -515,7 +525,7 @@
      }
  
      public void openEditSign(TileEntitySign signTile)
-@@ -1115,6 +1268,8 @@
+@@ -1115,6 +1272,8 @@
          }
          else
          {
@@ -524,7 +534,7 @@
              ItemStack itemstack = this.getHeldItem(p_190775_2_);
              ItemStack itemstack1 = itemstack.isEmpty() ? ItemStack.EMPTY : itemstack.copy();
  
-@@ -1124,7 +1279,10 @@
+@@ -1124,7 +1283,10 @@
                  {
                      itemstack.setCount(itemstack1.getCount());
                  }
@@ -536,7 +546,7 @@
                  return EnumActionResult.SUCCESS;
              }
              else
-@@ -1140,6 +1298,7 @@
+@@ -1140,6 +1302,7 @@
                      {
                          if (itemstack.isEmpty() && !this.capabilities.isCreativeMode)
                          {
@@ -544,7 +554,7 @@
                              this.setHeldItem(p_190775_2_, ItemStack.EMPTY);
                          }
  
-@@ -1165,6 +1324,7 @@
+@@ -1165,6 +1328,7 @@
  
      public void attackTargetEntityWithCurrentItem(Entity targetEntity)
      {
@@ -552,7 +562,7 @@
          if (targetEntity.canBeAttackedWithItem())
          {
              if (!targetEntity.hitByEntity(this))
-@@ -1203,9 +1363,11 @@
+@@ -1203,9 +1367,11 @@
                      boolean flag2 = flag && this.fallDistance > 0.0F && !this.onGround && !this.isOnLadder() && !this.isInWater() && !this.isPotionActive(MobEffects.BLINDNESS) && !this.isRiding() && targetEntity instanceof EntityLivingBase;
                      flag2 = flag2 && !this.isSprinting();
  
@@ -565,7 +575,7 @@
                      }
  
                      f = f + f1;
-@@ -1232,8 +1394,18 @@
+@@ -1232,8 +1398,18 @@
  
                          if (j > 0 && !targetEntity.isBurning())
                          {
@@ -586,7 +596,7 @@
                          }
                      }
  
-@@ -1268,8 +1440,10 @@
+@@ -1268,8 +1444,10 @@
                              {
                                  if (entitylivingbase != this && entitylivingbase != targetEntity && !this.isOnSameTeam(entitylivingbase) && this.getDistanceSq(entitylivingbase) < 9.0D)
                                  {
@@ -599,7 +609,7 @@
                                  }
                              }
  
-@@ -1277,13 +1451,30 @@
+@@ -1277,13 +1455,30 @@
                              this.spawnSweepParticles();
                          }
  
@@ -636,7 +646,7 @@
                          }
  
                          if (flag2)
-@@ -1332,10 +1523,12 @@
+@@ -1332,10 +1527,12 @@
  
                          if (!itemstack1.isEmpty() && entity instanceof EntityLivingBase)
                          {
@@ -649,7 +659,7 @@
                                  this.setHeldItem(EnumHand.MAIN_HAND, ItemStack.EMPTY);
                              }
                          }
-@@ -1347,7 +1540,15 @@
+@@ -1347,7 +1544,15 @@
  
                              if (j > 0)
                              {
@@ -666,7 +676,7 @@
                              }
  
                              if (this.world instanceof WorldServer && f5 > 2.0F)
-@@ -1357,7 +1558,8 @@
+@@ -1357,7 +1562,8 @@
                              }
                          }
  
@@ -676,7 +686,7 @@
                      }
                      else
                      {
-@@ -1367,6 +1569,11 @@
+@@ -1367,6 +1573,11 @@
                          {
                              targetEntity.extinguish();
                          }
@@ -688,7 +698,7 @@
                      }
                  }
              }
-@@ -1384,7 +1591,7 @@
+@@ -1384,7 +1595,7 @@
  
          if (this.rand.nextFloat() < f)
          {
@@ -697,7 +707,7 @@
              this.resetActiveHand();
              this.world.setEntityState(this, (byte)30);
          }
-@@ -1440,39 +1647,43 @@
+@@ -1440,39 +1651,43 @@
          return this.gameProfile;
      }
  
@@ -750,7 +760,7 @@
              }
          }
  
-@@ -1481,11 +1692,24 @@
+@@ -1481,11 +1696,24 @@
              this.dismountRidingEntity();
          }
  
@@ -777,7 +787,7 @@
              float f1 = 0.5F + (float)enumfacing.getFrontOffsetX() * 0.4F;
              float f = 0.5F + (float)enumfacing.getFrontOffsetZ() * 0.4F;
              this.setRenderOffsetForSleep(enumfacing);
-@@ -1508,7 +1732,7 @@
+@@ -1508,7 +1736,7 @@
              this.world.updateAllPlayersSleepingFlag();
          }
  
@@ -786,7 +796,7 @@
      }
  
      private boolean bedInRange(BlockPos p_190774_1_, EnumFacing p_190774_2_)
-@@ -1517,6 +1741,7 @@
+@@ -1517,6 +1745,7 @@
          {
              return true;
          }
@@ -794,7 +804,7 @@
          else
          {
              BlockPos blockpos = p_190774_1_.offset(p_190774_2_.getOpposite());
-@@ -1532,13 +1757,14 @@
+@@ -1532,13 +1761,14 @@
  
      public void wakeUpPlayer(boolean immediately, boolean updateWorldFlag, boolean setSpawn)
      {
@@ -813,7 +823,7 @@
  
              if (blockpos == null)
              {
-@@ -1547,6 +1773,10 @@
+@@ -1547,6 +1777,10 @@
  
              this.setPosition((double)((float)blockpos.getX() + 0.5F), (double)((float)blockpos.getY() + 0.1F), (double)((float)blockpos.getZ() + 0.5F));
          }
@@ -824,7 +834,7 @@
  
          this.sleeping = false;
  
-@@ -1555,6 +1785,23 @@
+@@ -1555,6 +1789,23 @@
              this.world.updateAllPlayersSleepingFlag();
          }
  
@@ -848,7 +858,7 @@
          this.sleepTimer = immediately ? 0 : 100;
  
          if (setSpawn)
-@@ -1565,15 +1812,16 @@
+@@ -1565,15 +1816,16 @@
  
      private boolean isInBed()
      {
@@ -868,7 +878,7 @@
          {
              if (!forceSpawn)
              {
-@@ -1588,16 +1836,17 @@
+@@ -1588,16 +1840,17 @@
          }
          else
          {
@@ -889,7 +899,7 @@
  
              switch (enumfacing)
              {
-@@ -1637,25 +1886,35 @@
+@@ -1637,25 +1890,35 @@
  
      public BlockPos getBedLocation()
      {
@@ -927,7 +937,7 @@
          }
      }
  
-@@ -1691,11 +1950,13 @@
+@@ -1691,11 +1954,13 @@
  
          if (this.isSprinting())
          {
@@ -943,7 +953,7 @@
          }
      }
  
-@@ -1714,7 +1975,10 @@
+@@ -1714,7 +1979,10 @@
              this.motionY = d3 * 0.6D;
              this.jumpMovementFactor = f;
              this.fallDistance = 0.0F;
@@ -955,7 +965,7 @@
          }
          else
          {
-@@ -1740,7 +2004,8 @@
+@@ -1740,7 +2008,8 @@
                  if (i > 0)
                  {
                      this.addStat(StatList.DIVE_ONE_CM, i);
@@ -965,7 +975,7 @@
                  }
              }
              else if (this.isInWater())
-@@ -1750,7 +2015,8 @@
+@@ -1750,7 +2019,8 @@
                  if (j > 0)
                  {
                      this.addStat(StatList.SWIM_ONE_CM, j);
@@ -975,7 +985,7 @@
                  }
              }
              else if (this.isOnLadder())
-@@ -1769,17 +2035,20 @@
+@@ -1769,17 +2039,20 @@
                      if (this.isSprinting())
                      {
                          this.addStat(StatList.SPRINT_ONE_CM, k);
@@ -999,7 +1009,7 @@
                      }
                  }
              }
-@@ -1839,6 +2108,10 @@
+@@ -1839,6 +2112,10 @@
  
              super.fall(distance, damageMultiplier);
          }
@@ -1010,7 +1020,7 @@
      }
  
      protected void doWaterSplashEffect()
-@@ -1943,6 +2216,7 @@
+@@ -1943,6 +2220,7 @@
  
      public void addExhaustion(float exhaustion)
      {
@@ -1018,7 +1028,7 @@
          if (!this.capabilities.disableDamage)
          {
              if (!this.world.isRemote)
-@@ -2115,10 +2389,16 @@
+@@ -2115,10 +2393,16 @@
  
      protected void spawnShoulderEntities()
      {
@@ -1039,7 +1049,7 @@
      }
  
      private void spawnShoulderEntity(@Nullable NBTTagCompound p_192026_1_)
-@@ -2137,6 +2417,23 @@
+@@ -2137,6 +2421,23 @@
          }
      }
  
@@ -1063,7 +1073,7 @@
      @SideOnly(Side.CLIENT)
      public boolean isInvisibleToPlayer(EntityPlayer player)
      {
-@@ -2176,7 +2473,10 @@
+@@ -2176,7 +2477,10 @@
  
      public ITextComponent getDisplayName()
      {
@@ -1075,7 +1085,7 @@
          itextcomponent.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.getName() + " "));
          itextcomponent.getStyle().setHoverEvent(this.getHoverEvent());
          itextcomponent.getStyle().setInsertion(this.getName());
-@@ -2185,7 +2485,7 @@
+@@ -2185,7 +2489,7 @@
  
      public float getEyeHeight()
      {
@@ -1084,7 +1094,7 @@
  
          if (this.isPlayerSleeping())
          {
-@@ -2368,7 +2668,7 @@
+@@ -2368,7 +2672,7 @@
          return (NBTTagCompound)this.dataManager.get(LEFT_SHOULDER_ENTITY);
      }
  
@@ -1093,7 +1103,7 @@
      {
          this.dataManager.set(LEFT_SHOULDER_ENTITY, tag);
      }
-@@ -2378,7 +2678,7 @@
+@@ -2378,7 +2682,7 @@
          return (NBTTagCompound)this.dataManager.get(RIGHT_SHOULDER_ENTITY);
      }
  
@@ -1102,7 +1112,7 @@
      {
          this.dataManager.set(RIGHT_SHOULDER_ENTITY, tag);
      }
-@@ -2421,13 +2721,175 @@
+@@ -2421,13 +2725,175 @@
          return this.capabilities.isCreativeMode && this.canUseCommand(2, "");
      }
  
@@ -1279,7 +1289,7 @@
          private final int chatVisibility;
          private final String resourceKey;
  
-@@ -2457,7 +2919,7 @@
+@@ -2457,7 +2923,7 @@
  
          static
          {
@@ -1288,7 +1298,7 @@
              {
                  ID_LOOKUP[entityplayer$enumchatvisibility.chatVisibility] = entityplayer$enumchatvisibility;
              }
-@@ -2488,4 +2950,9 @@
+@@ -2488,4 +2954,9 @@
          OTHER_PROBLEM,
          NOT_SAFE;
      }

--- a/patches/net/minecraft/network/datasync/EntityDataManager.java.patch
+++ b/patches/net/minecraft/network/datasync/EntityDataManager.java.patch
@@ -9,15 +9,19 @@
  import net.minecraft.crash.CrashReport;
  import net.minecraft.crash.CrashReportCategory;
  import net.minecraft.entity.Entity;
-@@ -26,7 +28,7 @@
+@@ -26,9 +28,9 @@
      private static final Logger LOGGER = LogManager.getLogger();
      private static final Map < Class <? extends Entity > , Integer > NEXT_ID_MAP = Maps. < Class <? extends Entity > , Integer > newHashMap();
      private final Entity entity;
 -    private final Map < Integer, EntityDataManager.DataEntry<? >> entries = Maps. < Integer, EntityDataManager.DataEntry<? >> newHashMap();
-+    private final Map < Integer, DataEntry<? >> entries = new Int2ObjectOpenHashMap<>(); // Paper
-     private final ReadWriteLock lock = new ReentrantReadWriteLock();
-     private boolean empty = true;
+-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+-    private boolean empty = true;
++    public final Map < Integer, DataEntry<? >> entries = new Int2ObjectOpenHashMap<>(); // Paper // CatServer - private -> public
++    public final ReadWriteLock lock = new ReentrantReadWriteLock(); // CatServer - private -> public
++    public boolean empty = true; // CatServer - private -> public
      private boolean dirty;
+ 
+     public EntityDataManager(Entity entityIn)
 @@ -38,7 +40,7 @@
  
      public static <T> DataParameter<T> createKey(Class <? extends Entity > clazz, DataSerializer<T> serializer)

--- a/patches/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/net/minecraft/server/management/PlayerList.java.patch
@@ -617,18 +617,20 @@
          playerIn.dimension = dimension;
          PlayerInteractionManager playerinteractionmanager;
  
-@@ -493,8 +848,20 @@
+@@ -493,8 +848,22 @@
          }
  
          EntityPlayerMP entityplayermp = new EntityPlayerMP(this.mcServer, this.mcServer.getWorld(playerIn.dimension), playerIn.getGameProfile(), playerinteractionmanager);
 +        */
 +        EntityPlayerMP entityplayermp = playerIn;
-+        // CatServer start - Call construct event and re-gather capabilities
-+        if (catserver.server.CatServer.getConfig().callConstructCapabilityEventOnRespawn) {
-+            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(entityplayermp));
-+            ((Entity) entityplayermp).capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(entityplayermp);
++        // CatServer start - Fix CB respawn logic
++        if (catserver.server.CatServer.getConfig().simulateVanillaRespawn) {
++            catserver.server.utils.ModFixUtils.simulateVanillaRespawn(entityplayermp);
 +        }
-+        // CatServer end - Call construct event and re-gather capabilities
++        if (catserver.server.CatServer.getConfig().regatherCapabilityOnRespawn) {
++            catserver.server.utils.ModFixUtils.regatherCapabilities(entityplayermp);
++        }
++        // CatServer end - Fix CB respawn logic
 +        org.bukkit.World fromWorld = playerIn.getBukkitEntity().getWorld();
 +        playerIn.queuedEndExit = false;
 +
@@ -638,7 +640,7 @@
          entityplayermp.setEntityId(playerIn.getEntityId());
          entityplayermp.setCommandStats(playerIn);
          entityplayermp.setPrimaryHand(playerIn.getPrimaryHand());
-@@ -504,44 +871,103 @@
+@@ -504,44 +873,103 @@
              entityplayermp.addTag(s);
          }
  
@@ -763,7 +765,7 @@
          return entityplayermp;
      }
  
-@@ -549,44 +975,125 @@
+@@ -549,44 +977,125 @@
      {
          GameProfile gameprofile = player.getGameProfile();
          int i = this.canSendCommands(gameprofile) ? this.ops.getPermissionLevel(gameprofile) : 0;
@@ -902,7 +904,7 @@
          {
              d0 = MathHelper.clamp(d0 / 8.0D, toWorldIn.getWorldBorder().minX() + 16.0D, toWorldIn.getWorldBorder().maxX() - 16.0D);
              d1 = MathHelper.clamp(d1 / 8.0D, toWorldIn.getWorldBorder().minZ() + 16.0D, toWorldIn.getWorldBorder().maxZ() - 16.0D);
-@@ -597,7 +1104,7 @@
+@@ -597,7 +1106,7 @@
                  oldWorldIn.updateEntityWithOptionalForce(entityIn, false);
              }
          }
@@ -911,7 +913,7 @@
          {
              d0 = MathHelper.clamp(d0 * 8.0D, toWorldIn.getWorldBorder().minX() + 16.0D, toWorldIn.getWorldBorder().maxX() - 16.0D);
              d1 = MathHelper.clamp(d1 * 8.0D, toWorldIn.getWorldBorder().minZ() + 16.0D, toWorldIn.getWorldBorder().maxZ() - 16.0D);
-@@ -608,7 +1115,7 @@
+@@ -608,7 +1117,7 @@
                  oldWorldIn.updateEntityWithOptionalForce(entityIn, false);
              }
          }
@@ -920,7 +922,7 @@
          {
              BlockPos blockpos;
  
-@@ -634,7 +1141,7 @@
+@@ -634,7 +1143,7 @@
  
          oldWorldIn.profiler.endSection();
  
@@ -929,7 +931,7 @@
          {
              oldWorldIn.profiler.startSection("placing");
              d0 = (double)MathHelper.clamp((int)d0, -29999872, 29999872);
-@@ -643,7 +1150,8 @@
+@@ -643,7 +1152,8 @@
              if (entityIn.isEntityAlive())
              {
                  entityIn.setLocationAndAngles(d0, entityIn.posY, d1, entityIn.rotationYaw, entityIn.rotationPitch);
@@ -939,7 +941,7 @@
                  toWorldIn.spawnEntity(entityIn);
                  toWorldIn.updateEntityWithOptionalForce(entityIn, false);
              }
-@@ -654,11 +1162,155 @@
+@@ -654,11 +1164,155 @@
          entityIn.setWorld(toWorldIn);
      }
  
@@ -1096,7 +1098,7 @@
              this.playerPingIndex = 0;
          }
      }
-@@ -671,6 +1323,24 @@
+@@ -671,6 +1325,24 @@
          }
      }
  
@@ -1121,7 +1123,7 @@
      public void sendPacketToAllPlayersInDimension(Packet<?> packetIn, int dimension)
      {
          for (int i = 0; i < this.playerEntityList.size(); ++i)
-@@ -786,12 +1456,20 @@
+@@ -786,12 +1458,20 @@
          int i = this.mcServer.getOpPermissionLevel();
          this.ops.addEntry(new UserListOpsEntry(profile, this.mcServer.getOpPermissionLevel(), this.ops.bypassesPlayerLimit(profile)));
          this.sendPlayerPermissionLevel(this.getPlayerByUUID(profile.getId()), i);
@@ -1142,7 +1144,7 @@
      }
  
      private void sendPlayerPermissionLevel(EntityPlayerMP player, int permLevel)
-@@ -824,7 +1502,7 @@
+@@ -824,7 +1504,7 @@
  
      public boolean canSendCommands(GameProfile profile)
      {
@@ -1151,7 +1153,7 @@
      }
  
      @Nullable
-@@ -847,6 +1525,12 @@
+@@ -847,6 +1527,12 @@
          {
              EntityPlayerMP entityplayermp = this.playerEntityList.get(i);
  
@@ -1164,7 +1166,7 @@
              if (entityplayermp != except && entityplayermp.dimension == dimension)
              {
                  double d0 = x - entityplayermp.posX;
-@@ -905,7 +1589,7 @@
+@@ -905,7 +1591,7 @@
  
      public void updateTimeAndWeatherForPlayer(EntityPlayerMP playerIn, WorldServer worldIn)
      {
@@ -1173,7 +1175,7 @@
          playerIn.connection.sendPacket(new SPacketWorldBorder(worldborder, SPacketWorldBorder.Action.INITIALIZE));
          playerIn.connection.sendPacket(new SPacketTimeUpdate(worldIn.getTotalWorldTime(), worldIn.getWorldTime(), worldIn.getGameRules().getBoolean("doDaylightCycle")));
          BlockPos blockpos = worldIn.getSpawnPoint();
-@@ -913,16 +1597,21 @@
+@@ -913,16 +1599,21 @@
  
          if (worldIn.isRaining())
          {
@@ -1199,7 +1201,7 @@
          playerIn.connection.sendPacket(new SPacketHeldItemChange(playerIn.inventory.currentItem));
      }
  
-@@ -938,7 +1627,7 @@
+@@ -938,7 +1629,7 @@
  
      public String[] getAvailablePlayerDat()
      {
@@ -1208,7 +1210,7 @@
      }
  
      public void setWhiteListEnabled(boolean whitelistEnabled)
-@@ -1004,17 +1693,26 @@
+@@ -1004,17 +1695,26 @@
  
      public void removeAllPlayers()
      {
@@ -1239,7 +1241,7 @@
      }
  
      public void sendMessage(ITextComponent component)
-@@ -1022,6 +1720,7 @@
+@@ -1022,6 +1722,7 @@
          this.sendMessage(component, true);
      }
  
@@ -1247,7 +1249,7 @@
      public StatisticsManagerServer getPlayerStatsFile(EntityPlayer playerIn)
      {
          UUID uuid = playerIn.getUniqueID();
-@@ -1050,6 +1749,8 @@
+@@ -1050,6 +1751,8 @@
          return statisticsmanagerserver;
      }
  
@@ -1256,7 +1258,7 @@
      public PlayerAdvancements getPlayerAdvancements(EntityPlayerMP p_192054_1_)
      {
          UUID uuid = p_192054_1_.getUniqueID();
-@@ -1073,7 +1774,7 @@
+@@ -1073,7 +1776,7 @@
  
          if (this.mcServer.worlds != null)
          {

--- a/patches/net/minecraft/world/Explosion.java.patch
+++ b/patches/net/minecraft/world/Explosion.java.patch
@@ -31,7 +31,7 @@
 -    private final Entity exploder;
 -    private final float size;
 +    public final Entity exploder;
-+    public float size; // CatServer - private final -> public
++    public final float size; // CatServer - private -> public
      private final List<BlockPos> affectedBlockPositions;
      private final Map<EntityPlayer, Vec3d> playerKnockbackMap;
 +    private final Vec3d position;

--- a/src/main/java/catserver/server/CatServerConfig.java
+++ b/src/main/java/catserver/server/CatServerConfig.java
@@ -56,8 +56,9 @@ public class CatServerConfig {
     public boolean disableAsyncCatchWarn = false;
     public boolean versionCheck = true;
 
+    public boolean regatherCapabilityOnRespawn = false;
+    public boolean simulateVanillaRespawn = false;
     public boolean bridgeForgeExplosionEventToBukkit = false;
-    public boolean callConstructCapabilityEventOnRespawn = false;
 
     public CatServerConfig(String file) {
         this.configFile = new File(file);
@@ -107,8 +108,9 @@ public class CatServerConfig {
         disableFMLHandshake = getOrWriteBooleanConfig("network.fml.disableHandshake", config.getBoolean("disableFMLHandshake", disableFMLHandshake));
         disableFMLStatusModInfo = getOrWriteBooleanConfig("network.fml.disableStatusModInfo", config.getBoolean("disableFMLStatusModInfo", disableFMLStatusModInfo));
         // compatibility
+        regatherCapabilityOnRespawn = getOrWriteBooleanConfig("compatibility.regatherCapabilityOnRespawn", regatherCapabilityOnRespawn);
+        simulateVanillaRespawn = getOrWriteBooleanConfig("compatibility.simulateVanillaRespawn", simulateVanillaRespawn);
         bridgeForgeExplosionEventToBukkit = getOrWriteBooleanConfig("compatibility.bridgeForgeExplosionEventToBukkit", bridgeForgeExplosionEventToBukkit);
-        callConstructCapabilityEventOnRespawn = getOrWriteBooleanConfig("compatibility.callConstructCapabilityEventOnRespawn", callConstructCapabilityEventOnRespawn);
         // general
         disableUpdateGameProfile = getOrWriteBooleanConfig("disableUpdateGameProfile", disableUpdateGameProfile);
         disableAsyncCatchWarn = getOrWriteBooleanConfig("disableAsyncCatchWarn", disableAsyncCatchWarn);

--- a/src/main/java/catserver/server/CatServerEventHandler.java
+++ b/src/main/java/catserver/server/CatServerEventHandler.java
@@ -88,7 +88,6 @@ public class CatServerEventHandler {
             Location location = new Location(bworld, explosionPos.x, explosionPos.y, explosionPos.z);
             List<Block> bukkitBlocks;
             boolean cancelled;
-            float yield;
             final List<Block> blockList = Lists.newArrayList();
             List<BlockPos> affectedBlockPositions = event.getAffectedBlocks();
             for (int i1 = affectedBlockPositions.size() - 1; i1 >= 0; i1--) {
@@ -103,13 +102,11 @@ public class CatServerEventHandler {
                 Bukkit.getServer().getPluginManager().callEvent(bukkitEvent);
                 cancelled = bukkitEvent.isCancelled();
                 bukkitBlocks = bukkitEvent.blockList();
-                yield = bukkitEvent.getYield();
             } else {
                 BlockExplodeEvent bukkitEvent = new BlockExplodeEvent(location.getBlock(), blockList, 1.0F / explosion.size);
                 Bukkit.getServer().getPluginManager().callEvent(bukkitEvent);
                 cancelled = bukkitEvent.isCancelled();
                 bukkitBlocks = bukkitEvent.blockList();
-                yield = bukkitEvent.getYield();
             }
             explosion.getAffectedBlockPositions().clear();
 
@@ -121,7 +118,6 @@ public class CatServerEventHandler {
                     BlockPos coords = new BlockPos(bblock.getX(), bblock.getY(), bblock.getZ());
                     explosion.getAffectedBlockPositions().add(coords);
                 }
-                explosion.size = yield * explosion.size;
             }
         }
     }

--- a/src/main/java/catserver/server/utils/ModFixUtils.java
+++ b/src/main/java/catserver/server/utils/ModFixUtils.java
@@ -1,11 +1,18 @@
 package catserver.server.utils;
 
 import catserver.server.CatServer;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
+import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.fml.common.Loader;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 
@@ -42,5 +49,67 @@ public class ModFixUtils {
                 }
             }
         }
+    }
+
+    public static void simulateVanillaRespawn(EntityPlayerMP playerIn) {
+        final EntityDataManager dataManager = playerIn.getDataManager();
+        // Capture vanilla values
+        // Entity
+        byte capturedFlags = dataManager.get(Entity.FLAGS);
+        int capturedAirTicks = dataManager.get(Entity.AIR);
+        String capturedCustomName = dataManager.get(Entity.CUSTOM_NAME);
+        boolean capturedCustomNameVisible = dataManager.get(Entity.CUSTOM_NAME_VISIBLE);
+        boolean capturedSilent = dataManager.get(Entity.SILENT);
+        boolean capturedNoGravity = dataManager.get(Entity.NO_GRAVITY);
+        // EntityLivingBase
+        byte capturedHandStates = dataManager.get(EntityLivingBase.HAND_STATES);
+        float capturedHealth = dataManager.get(EntityLivingBase.HEALTH);
+        int capturedPotionEffects = dataManager.get(EntityLivingBase.POTION_EFFECTS);
+        boolean capturedHideParticles = dataManager.get(EntityLivingBase.HIDE_PARTICLES);
+        int capturedArrowCount = dataManager.get(EntityLivingBase.ARROW_COUNT_IN_ENTITY);
+        // EntityPlayer
+        float capturedAbsorptionAmount = dataManager.get(EntityPlayer.ABSORPTION);
+        int capturedScore = dataManager.get(EntityPlayer.PLAYER_SCORE);
+        byte capturedPlayerModelFlag = dataManager.get(EntityPlayer.PLAYER_MODEL_FLAG);
+        byte capturedMainHand = dataManager.get(EntityPlayer.MAIN_HAND);
+        NBTTagCompound capturedLeftShoulder = dataManager.get(EntityPlayer.LEFT_SHOULDER_ENTITY);
+        NBTTagCompound capturedRightShoulder = dataManager.get(EntityPlayer.RIGHT_SHOULDER_ENTITY);
+
+        try {
+            dataManager.lock.writeLock().lock();
+            dataManager.entries.clear();
+        } finally {
+            dataManager.lock.writeLock().unlock();
+        }
+        dataManager.empty = true;
+        dataManager.setClean();
+
+        // Restore captured vanilla values
+        // Entity
+        dataManager.register(Entity.FLAGS, capturedFlags);
+        dataManager.register(Entity.AIR, capturedAirTicks);
+        dataManager.register(Entity.CUSTOM_NAME, capturedCustomName);
+        dataManager.register(Entity.CUSTOM_NAME_VISIBLE, capturedCustomNameVisible);
+        dataManager.register(Entity.SILENT, capturedSilent);
+        dataManager.register(Entity.NO_GRAVITY, capturedNoGravity);
+        // EntityLivingBase
+        dataManager.register(EntityLivingBase.HAND_STATES, capturedHandStates);
+        dataManager.register(EntityLivingBase.HEALTH, capturedHealth);
+        dataManager.register(EntityLivingBase.POTION_EFFECTS, capturedPotionEffects);
+        dataManager.register(EntityLivingBase.HIDE_PARTICLES, capturedHideParticles);
+        dataManager.register(EntityLivingBase.ARROW_COUNT_IN_ENTITY, capturedArrowCount);
+        // EntityPlayer
+        dataManager.register(EntityPlayer.ABSORPTION, capturedAbsorptionAmount);
+        dataManager.register(EntityPlayer.PLAYER_SCORE, capturedScore);
+        dataManager.register(EntityPlayer.PLAYER_MODEL_FLAG, capturedPlayerModelFlag);
+        dataManager.register(EntityPlayer.MAIN_HAND, capturedMainHand);
+        dataManager.register(EntityPlayer.LEFT_SHOULDER_ENTITY, capturedLeftShoulder);
+        dataManager.register(EntityPlayer.RIGHT_SHOULDER_ENTITY, capturedRightShoulder);
+
+        MinecraftForge.EVENT_BUS.post(new EntityEvent.EntityConstructing(playerIn));
+    }
+
+    public static void regatherCapabilities(EntityPlayerMP playerIn) {
+        ((Entity) playerIn).capabilities = ForgeEventFactory.gatherCapabilities(playerIn);
     }
 }


### PR DESCRIPTION
This pull request attempts to simulate vanilla respawn logic by calling methods originally called in constructors, as CraftBukkit respawn logic reuses player instance instead of creating a new one.

Some mods re-register DataParameter on ConstructEvent, the previous fix will cause IllegalStateException issues if mods do not check the param has been already registered.

The new fix captures all vanilla data values, clear DataManager then restore vanilla data values.

Fixes #204 