### PR TITLE
Fix Spigot NMS ChunkProviderServer remap

### DIFF
--- a/patches/net/minecraft/world/gen/ChunkProviderServer.java.patch
+++ b/patches/net/minecraft/world/gen/ChunkProviderServer.java.patch
@@ -90,7 +90,7 @@
              long i = ChunkPos.asLong(x, z);
  
              try
-@@ -126,7 +163,8 @@
+@@ -126,12 +163,52 @@
  
              this.id2ChunkMap.put(i, chunk);
              chunk.onLoad();
@@ -100,7 +100,51 @@
          }
  
          return chunk;
-@@ -218,36 +256,91 @@
+     }
+ 
++    // CatServer start
++    public Chunk provideChunk(int x, int z, Runnable runnable)
++    {
++        return provideChunk(x, z, runnable, true);
++    }
++
++    public Chunk provideChunk(int x, int z, Runnable runnable, boolean generate)
++    {
++        Chunk chunk = this.loadChunk(x, z, runnable);
++
++        if (chunk == null && generate)
++        {
++            world.timings.syncChunkLoadTimer.startTiming(); // Spigot
++            long i = ChunkPos.asLong(x, z);
++
++            try
++            {
++                chunk = this.chunkGenerator.generateChunk(x, z);
++            }
++            catch (Throwable throwable)
++            {
++                CrashReport crashreport = CrashReport.makeCrashReport(throwable, "Exception generating new chunk");
++                CrashReportCategory crashreportcategory = crashreport.makeCategory("Chunk to be generated");
++                crashreportcategory.addCrashSection("Location", String.format("%d,%d", x, z));
++                crashreportcategory.addCrashSection("Position hash", Long.valueOf(i));
++                crashreportcategory.addCrashSection("Generator", this.chunkGenerator);
++                throw new ReportedException(crashreport);
++            }
++
++            this.id2ChunkMap.put(i, chunk);
++            chunk.onLoad();
++            chunk.populateCB(this, this.chunkGenerator, true);
++            world.timings.syncChunkLoadTimer.stopTiming(); // Spigot
++        }
++
++        return chunk;
++    }
++    // CatServer end
++
+     @Nullable
+     private Chunk loadChunkFromFile(int x, int z)
+     {
+@@ -218,36 +295,91 @@
          this.chunkLoader.flush();
      }
  

--- a/src/main/resources/mappings/v1_12_R1/cb2srg.srg
+++ b/src/main/resources/mappings/v1_12_R1/cb2srg.srg
@@ -13691,6 +13691,8 @@ MD: net/minecraft/server/ChunkProviderServer/e (II)Z net/minecraft/world/gen/Chu
 MD: net/minecraft/server/ChunkProviderServer/f ()Ljava/lang/String; net/minecraft/world/gen/ChunkProviderServer/func_73148_d ()Ljava/lang/String;
 MD: net/minecraft/server/ChunkProviderServer/g ()I net/minecraft/world/gen/ChunkProviderServer/func_73152_e ()I
 MD: net/minecraft/server/ChunkProviderServer/getOrLoadChunkAt (II)Lnet/minecraft/server/Chunk; net/minecraft/world/gen/ChunkProviderServer/func_186028_c (II)Lnet/minecraft/world/chunk/Chunk;
+MD: net/minecraft/server/ChunkProviderServer/getChunkAt (IILjava/lang/Runnable;)Lnet/minecraft/server/Chunk; net/minecraft/world/gen/ChunkProviderServer/provideChunk (IILjava/lang/Runnable;)Lnet/minecraft/world/chunk/Chunk;
+MD: net/minecraft/server/ChunkProviderServer/getChunkAt (IILjava/lang/Runnable;Z)Lnet/minecraft/server/Chunk; net/minecraft/world/gen/ChunkProviderServer/provideChunk (IILjava/lang/Runnable;Z)Lnet/minecraft/world/chunk/Chunk;
 MD: net/minecraft/server/ChunkProviderServer/isLoaded (II)Z net/minecraft/world/gen/ChunkProviderServer/func_73149_a (II)Z
 MD: net/minecraft/server/ChunkProviderServer/loadChunk (II)Lnet/minecraft/server/Chunk; net/minecraft/world/gen/ChunkProviderServer/func_73239_e (II)Lnet/minecraft/world/chunk/Chunk;
 MD: net/minecraft/server/ChunkProviderServer/saveChunk (Lnet/minecraft/server/Chunk;)V net/minecraft/world/gen/ChunkProviderServer/func_73242_b (Lnet/minecraft/world/chunk/Chunk;)V


### PR DESCRIPTION
This pull request added some Spigot's helper methods in ChunkProviderServer, as some plugins that touch NMS will use them.

### Changes
- Mappings
- Add more `provideChunk` methods to ChunkProviderServer