### PR TITLE
[1.18.2] Some updates

### DIFF
--- a/foxlaunch/src/main/java/foxlaunch/FoxServerLauncher.java
+++ b/foxlaunch/src/main/java/foxlaunch/FoxServerLauncher.java
@@ -53,13 +53,13 @@ public class FoxServerLauncher {
                 DataManager.getVersionData("mcp")
         };
 
-        launchArgs = Arrays.copyOf(launchArgs, launchArgs.length + args.length);
-        System.arraycopy(args, 0, launchArgs, launchArgs.length, args.length);
+        final String[] finalLaunchArgs = Arrays.copyOf(launchArgs, launchArgs.length + args.length);
+        System.arraycopy(args, 0, finalLaunchArgs, launchArgs.length, args.length);
 
         DataManager.gc();
         System.setProperty("log4j.configurationFile", "log4j2-catserver.xml");
 
-        Class.forName("cpw.mods.bootstraplauncher.BootstrapLauncher").getMethod("main", String[].class).invoke(null, new Object[] { launchArgs } );
+        Class.forName("cpw.mods.bootstraplauncher.BootstrapLauncher").getMethod("main", String[].class).invoke(null, new Object[] { finalLaunchArgs } );
     }
 
     private static boolean checkJavaVersion() {

--- a/patches/minecraft/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java.patch
+++ b/patches/minecraft/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java
 +++ b/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java
-@@ -20,13 +_,39 @@
+@@ -20,13 +_,37 @@
  import net.minecraft.world.level.block.state.BlockState;
  import net.minecraft.world.level.gameevent.GameEvent;
  import net.minecraft.world.phys.AABB;
@@ -8,8 +8,6 @@
 +import org.bukkit.craftbukkit.v1_18_R2.event.CraftEventFactory;
 +import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 +import org.bukkit.event.block.BlockDispenseEvent;
-+
-+import java.util.concurrent.atomic.AtomicReference;
  
  public class ShearsDispenseItemBehavior extends OptionalDispenseItemBehavior {
     protected ItemStack m_7498_(BlockSource p_123580_, ItemStack p_123581_) {
@@ -41,17 +39,20 @@
           if (this.m_123570_() && p_123581_.m_41629_(1, level.m_5822_(), (ServerPlayer)null)) {
              p_123581_.m_41764_(0);
           }
-@@ -53,11 +_,27 @@
+@@ -53,11 +_,30 @@
        return false;
     }
  
 +   // CatServer start
-+   private static AtomicReference<Block> catserver$shearBukkitBlock = new AtomicReference<>();
-+   private static AtomicReference<CraftItemStack> catserver$shearCraftItem = new AtomicReference<>();
 +   private static boolean tryShearLivingEntity(ServerLevel p_123583_, BlockPos p_123584_, org.bukkit.block.Block bukkitBlock, CraftItemStack craftItem) { // CraftBukkit - add args
-+      ShearsDispenseItemBehavior.catserver$shearBukkitBlock.set(bukkitBlock);
-+      ShearsDispenseItemBehavior.catserver$shearCraftItem.set(craftItem);
-+      return m_123582_(p_123583_, p_123584_);
++      try {
++         catserver.server.CatServerCaptures.getCatServerCaptures().captureShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlock(bukkitBlock);
++         catserver.server.CatServerCaptures.getCatServerCaptures().captureShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStack(craftItem);
++         return m_123582_(p_123583_, p_123584_);
++      } finally {
++         catserver.server.CatServerCaptures.getCatServerCaptures().resetCaptureShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlock();
++         catserver.server.CatServerCaptures.getCatServerCaptures().resetCaptureShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStack();
++      }
 +   }
 +
     private static boolean m_123582_(ServerLevel p_123583_, BlockPos p_123584_) {
@@ -60,8 +61,8 @@
              Shearable shearable = (Shearable)livingentity;
              if (shearable.m_6220_()) {
 +               // CraftBukkit start
-+               var bukkitBlock = ShearsDispenseItemBehavior.catserver$shearBukkitBlock.getAndSet(null);
-+               var craftItem = ShearsDispenseItemBehavior.catserver$shearCraftItem.getAndSet(null);
++               var bukkitBlock = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlockWithoutReset();
++               var craftItem = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStackWithoutReset();
 +               if (CraftEventFactory.callBlockShearEntityEvent(livingentity, bukkitBlock, craftItem).isCancelled()) {
 +                  continue;
 +               }
@@ -69,3 +70,9 @@
                 shearable.m_5851_(SoundSource.BLOCKS);
                 p_123583_.m_142346_((Entity)null, GameEvent.f_157781_, p_123584_);
                 return true;
+@@ -67,4 +_,5 @@
+ 
+       return false;
+    }
++   // CatServer end
+ }

--- a/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -145,1399 +_,1814 @@
+@@ -145,1399 +_,1815 @@
  import net.minecraft.world.phys.shapes.Shapes;
  import net.minecraft.world.phys.shapes.VoxelShape;
  import net.minecraft.world.ticks.LevelTicks;
@@ -1555,9 +1555,10 @@
 +                    return p_8664_.m_6095_().getRegistryName() == null ? p_8664_.m_6095_().toString() : p_8664_.m_6095_().getRegistryName().toString();
 +                });
 +                profilerfiller.m_6174_("tickPassenger");
-+                if (p_8664_.canUpdate())
++                if (p_8664_.canUpdate()) {
 +                    p_8664_.m_6083_();
-+                p_8664_.postTick(); // CraftBukkit
++                    p_8664_.postTick(); // CraftBukkit
++                }
 +                profilerfiller.m_7238_();
 +
 +                for (Entity entity : p_8664_.m_20197_()) {

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -131,7 +131,7 @@
  import net.minecraft.world.level.block.Blocks;
  import net.minecraft.world.level.block.CommandBlock;
  import net.minecraft.world.level.block.entity.BlockEntity;
-@@ -141,1317 +_,2388 @@
+@@ -141,1317 +_,2389 @@
  import net.minecraft.world.level.block.entity.JigsawBlockEntity;
  import net.minecraft.world.level.block.entity.SignBlockEntity;
  import net.minecraft.world.level.block.entity.StructureBlockEntity;
@@ -2436,6 +2436,7 @@
 +        this.server.invalidateStatus();
 +        this.server.getPlayerList().broadcastMessage((new TranslatableComponent("multiplayer.player.left", this.player.getDisplayName())).withStyle(ChatFormatting.YELLOW), ChatType.SYSTEM, Util.NIL_UUID);
 +        */
++        this.f_9743_.m_9231_();
 +        String quitMessage = this.f_9745_.m_6846_().removeCb(this.f_9743_);
 +        if ((quitMessage != null) && (quitMessage.length() > 0)) {
 +            this.f_9745_.m_6846_().broadcastMessage(CraftChatMessage.fromString(quitMessage));

--- a/patches/minecraft/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java.patch
@@ -37,7 +37,7 @@
 +            synchronized (throttleTracker) {
 +               if (throttleTracker.containsKey(address) && !"127.0.0.1".equals(address.getHostAddress()) && currentTime - throttleTracker.get(address) < connectionThrottle) {
 +                  throttleTracker.put(address, currentTime);
-+                  TranslatableComponent chatmessage = new TranslatableComponent("Connection throttled! Please wait before reconnecting.");
++                  Component chatmessage = new TextComponent("Connection throttled! Please wait before reconnecting.");
 +                  this.f_9966_.m_129512_(new ClientboundLoginDisconnectPacket(chatmessage));
 +                  this.f_9966_.m_129507_(chatmessage);
 +                  return;
@@ -64,10 +64,10 @@
              Component component;
              if (p_9975_.m_134738_() < 754) {
 -               component = new TranslatableComponent("multiplayer.disconnect.outdated_client", SharedConstants.m_183709_().getName());
-+               component = new TranslatableComponent(java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedClientMessage.replaceAll("'", "''"), SharedConstants.m_183709_().getName() ) ); // Spigot
++               component = new TextComponent(java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedClientMessage.replaceAll("'", "''"), SharedConstants.m_183709_().getName() ) ); // Spigot
              } else {
 -               component = new TranslatableComponent("multiplayer.disconnect.incompatible", SharedConstants.m_183709_().getName());
-+               component = new TranslatableComponent(java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedServerMessage.replaceAll("'", "''"), SharedConstants.m_183709_().getName() ) ); // Spigot
++               component = new TextComponent(java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedServerMessage.replaceAll("'", "''"), SharedConstants.m_183709_().getName() ) ); // Spigot
              }
  
              this.f_9966_.m_129512_(new ClientboundLoginDisconnectPacket(component));
@@ -83,7 +83,7 @@
 +                  f_9966_.spoofedUUID = com.mojang.util.UUIDTypeAdapter.fromString( split[2] );
 +               } else
 +               {
-+                  TranslatableComponent chatmessage = new TranslatableComponent("If you wish to use IP forwarding, please enable it in your BungeeCord config as well!");
++                  Component chatmessage = new TextComponent("If you wish to use IP forwarding, please enable it in your BungeeCord config as well!");
 +                  this.f_9966_.m_129512_(new ClientboundLoginDisconnectPacket(chatmessage));
 +                  this.f_9966_.m_129507_(chatmessage);
 +                  return;
@@ -93,7 +93,7 @@
 +                  f_9966_.spoofedProfile = gson.fromJson(split[3], com.mojang.authlib.properties.Property[].class);
 +               }
 +            } else if ( ( split.length == 3 || split.length == 4 ) && ( HOST_PATTERN.matcher( split[1] ).matches() ) ) {
-+               TranslatableComponent chatmessage = new TranslatableComponent("Unknown data in login hostname, did you forget to enable BungeeCord in spigot.yml?");
++               Component chatmessage = new TextComponent("Unknown data in login hostname, did you forget to enable BungeeCord in spigot.yml?");
 +               this.f_9966_.m_129512_(new ClientboundLoginDisconnectPacket(chatmessage));
 +               this.f_9966_.m_129507_(chatmessage);
 +               return;

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -888,7 +888,7 @@
     }
  
     public boolean m_7306_(Entity p_20356_) {
-@@ -2237,32 +_,80 @@
+@@ -2237,32 +_,84 @@
  
     @Nullable
     public Entity m_5489_(ServerLevel p_20118_) {
@@ -920,17 +920,21 @@
 +   public Entity changeDimension(ServerLevel p_20118_, net.minecraftforge.common.util.ITeleporter teleporter) {
 +      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_20118_.m_46472_())) return null;
        if (this.f_19853_ instanceof ServerLevel && !this.m_146910_()) {
-          this.f_19853_.m_46473_().m_6180_("changeDimension");
--         this.m_19877_();
 +         // CatServer start
 +         if (p_20118_ == null) {
 +            return null;
 +         }
 +         // CatServer end
+          this.f_19853_.m_46473_().m_6180_("changeDimension");
+-         this.m_19877_();
           this.f_19853_.m_46473_().m_6180_("reposition");
 -         PortalInfo portalinfo = this.m_7937_(p_20118_);
 +         PortalInfo portalinfo = teleporter.getPortalInfo(this, p_20118_, this::m_7937_);
           if (portalinfo == null) {
++            // CatServer start - ensure pop
++            this.f_19853_.m_46473_().m_7238_();
++            this.f_19853_.m_46473_().m_7238_();
++            // CatServer end
              return null;
           } else {
 +            // CatServer start
@@ -953,7 +957,7 @@
 -                  ServerLevel.m_8617_(p_20118_);
 +               serverLevel.m_143334_(entity);
 +               if (spawnPortal && serverLevel.m_46472_() == Level.f_46430_) {
-+                  ServerLevel.m_8617_(serverLevel);
++                  ServerLevel.makeObsidianPlatform(serverLevel, this);
 +               }
 +               // CraftBukkit start - Forward the CraftEntity to the new entity
 +               this.getBukkitEntity().setHandle(entity);

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -190,9 +190,9 @@
 +            if (!p_20992_.addLandingEffects((ServerLevel)this.f_19853_, p_20993_, p_20992_, this, i))
 +               // CraftBukkit start - visiblity api
 +               if (this instanceof ServerPlayer) {
-+                  ((ServerLevel) this.f_19853_).sendParticles((ServerPlayer) this, new BlockParticleOption(ParticleTypes.f_123794_, p_20992_), this.m_20185_(), this.m_20186_(), this.m_20189_(), i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, false);
++                  ((ServerLevel) this.f_19853_).sendParticles((ServerPlayer) this, new BlockParticleOption(ParticleTypes.f_123794_, p_20992_).setPos(p_20993_), this.m_20185_(), this.m_20186_(), this.m_20189_(), i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, false);
 +               } else {
-+                  ((ServerLevel) this.f_19853_).m_8767_(new BlockParticleOption(ParticleTypes.f_123794_, p_20992_), this.m_20185_(), this.m_20186_(), this.m_20189_(), i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D);
++                  ((ServerLevel) this.f_19853_).m_8767_(new BlockParticleOption(ParticleTypes.f_123794_, p_20992_).setPos(p_20993_), this.m_20185_(), this.m_20186_(), this.m_20189_(), i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D);
 +               }
 +            // CraftBukkit end
           }
@@ -364,14 +364,14 @@
     }
  
 +   // CatServer start - Fix mixin conflict with respiteful Mod
-+   @Nullable
-+   private EntityPotionEffectEvent.Cause potionEffectCause;
++   @javax.annotation.Nonnull
++   private EntityPotionEffectEvent.Cause potionEffectCause = EntityPotionEffectEvent.Cause.UNKNOWN;
 +
-+   private void potionEffectCause(EntityPotionEffectEvent.Cause cause) {
++   private void potionEffectCause(@javax.annotation.Nonnull EntityPotionEffectEvent.Cause cause) {
 +      this.potionEffectCause = cause;
 +   }
 +
-+   @Nullable
++   @javax.annotation.Nonnull
 +   private EntityPotionEffectEvent.Cause potionEffectCause() {
 +      return potionEffectCause;
 +   }
@@ -487,7 +487,7 @@
  
     protected void m_142540_(MobEffectInstance p_147190_, @Nullable Entity p_147191_) {
        this.f_20948_ = true;
-@@ -963,19 +_,71 @@
+@@ -963,19 +_,74 @@
  
     }
  
@@ -503,8 +503,12 @@
 +   }
 +
 +   public void heal(float p_21116_, EntityRegainHealthEvent.RegainReason regainReason) {
-+      this.setRegainReason(regainReason);
-+      this.m_5634_(p_21116_);
++      try {
++         this.setRegainReason(regainReason);
++         this.m_5634_(p_21116_);
++      } finally {
++         this.resetRegainReason();
++      }
 +   }
 +
     public void m_5634_(float p_21116_) {
@@ -514,7 +518,6 @@
        if (f > 0.0F) {
 -         this.m_21153_(f + p_21116_);
 +         EntityRegainHealthEvent.RegainReason reason = this.regainReason;
-+         this.resetRegainReason();
 +
 +         if (reason == null) {
 +            reason = EntityRegainHealthEvent.RegainReason.CUSTOM;
@@ -1038,7 +1041,7 @@
 +
 +         float originalDamage = f;
 +         Function<Double, Double> hardHat = f12 -> {
-+            if ((damagesource == DamageSource.f_19321_ || damagesource == DamageSource.f_19322_) && !this.m_6844_(EquipmentSlot.HEAD).m_41619_()) {
++            if (damagesource.m_146705_() && !this.m_6844_(EquipmentSlot.HEAD).m_41619_()) {
 +               return -(f12 - (f12 * 0.75F));
 +            }
 +            return -0.0;
@@ -1531,13 +1534,11 @@
     public boolean m_20984_(double p_20985_, double p_20986_, double p_20987_, boolean p_20988_) {
        double d0 = this.m_20185_();
        double d1 = this.m_20186_();
-@@ -2998,16 +_,40 @@
-             }
+@@ -2999,15 +_,39 @@
           }
  
--         if (flag1) {
+          if (flag1) {
 -            this.m_6021_(p_20985_, d3, p_20987_);
-+         if (flag) {
 +            var cause = CatServerCaptures.getCatServerCaptures().getCaptureTeleportCause();
 +            // CraftBukkit start - Teleport event
 +            // this.teleportTo(p_20985_, d3, p_20987_);
@@ -1548,7 +1549,7 @@
              }
 +            // now revert and call event if the teleport place is valid
 +            this.m_6034_(d0, d1, d2);
-+            if (flag1) {
++            if (flag) {
 +               if (!(this instanceof ServerPlayer)) {
 +                  EntityTeleportEvent teleport = new EntityTeleportEvent(this.getBukkitEntity(), new Location(this.f_19853_.getWorld(), d0, d1, d2), new Location(this.f_19853_.getWorld(), p_20985_, d3, p_20987_));
 +                  this.f_19853_.getCraftServer().getPluginManager().callEvent(teleport);
@@ -1625,16 +1626,21 @@
     }
  
     public ItemStack m_5584_(Level p_21067_, ItemStack p_21068_) {
-@@ -3160,9 +_,12 @@
+@@ -3160,9 +_,16 @@
     private void m_21063_(ItemStack p_21064_, Level p_21065_, LivingEntity p_21066_) {
        Item item = p_21064_.m_41720_();
        if (item.m_41472_()) {
 -         for(Pair<MobEffectInstance, Float> pair : item.m_41473_().m_38749_()) {
 +         for(Pair<MobEffectInstance, Float> pair : p_21064_.getFoodProperties(this).m_38749_()) {
              if (!p_21065_.f_46443_ && pair.getFirst() != null && p_21065_.f_46441_.nextFloat() < pair.getSecond()) {
+-               p_21066_.m_7292_(new MobEffectInstance(pair.getFirst()));
 +               // CatServer start - Fix mixin conflict with respiteful Mod
-+               p_21066_.potionEffectCause(EntityPotionEffectEvent.Cause.FOOD);
-                p_21066_.m_7292_(new MobEffectInstance(pair.getFirst()));
++               try {
++                  p_21066_.potionEffectCause(EntityPotionEffectEvent.Cause.FOOD);
++                  p_21066_.m_7292_(new MobEffectInstance(pair.getFirst()));
++               } finally {
++                  p_21066_.potionEffectCause(EntityPotionEffectEvent.Cause.UNKNOWN);
++               }
 +               // CatServer end
              }
           }

--- a/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/world/entity/Mob.java
 +++ b/net/minecraft/world/entity/Mob.java
-@@ -6,6 +_,7 @@
- import java.util.Optional;
- import java.util.Random;
- import java.util.UUID;
-+import java.util.concurrent.atomic.AtomicReference;
- import javax.annotation.Nullable;
- import net.minecraft.core.BlockPos;
- import net.minecraft.core.NonNullList;
 @@ -21,6 +_,7 @@
  import net.minecraft.network.syncher.SynchedEntityData;
  import net.minecraft.resources.ResourceLocation;
@@ -253,36 +245,33 @@
           this.m_21463_(p_21500_, true);
           itemstack.m_41774_(1);
           return InteractionResult.m_19078_(this.f_19853_.f_46443_);
-@@ -1116,11 +_,23 @@
+@@ -1116,6 +_,19 @@
        return this.f_21341_ != -1.0F;
     }
  
 +   // CatServer start
-+   private AtomicReference<EntityTransformEvent.TransformReason> catserver$transformReason = new AtomicReference<>(EntityTransformEvent.TransformReason.UNKNOWN);
-+   private AtomicReference<CreatureSpawnEvent.SpawnReason> catserver$spawnReason = new AtomicReference(CreatureSpawnEvent.SpawnReason.DEFAULT);
 +   @Nullable
 +   public <T extends Mob> T convertTo(EntityType<T> p_21407_, boolean p_21408_, EntityTransformEvent.TransformReason transformReason, CreatureSpawnEvent.SpawnReason spawnReason) {
-+      this.catserver$transformReason.set(transformReason);
-+      this.catserver$spawnReason.set(spawnReason);
-+      return this.m_21406_(p_21407_, p_21408_);
++      try {
++         catserver.server.CatServerCaptures.getCatServerCaptures().captureMob$convertTo$transformReason(transformReason);
++         catserver.server.CatServerCaptures.getCatServerCaptures().captureMob$convertTo$spawnReason(spawnReason);
++         return this.m_21406_(p_21407_, p_21408_);
++      } finally {
++         catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureMob$convertTo$transformReason();
++         catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureMob$convertTo$spawnReason();
++      }
 +   }
 +
     @Nullable
     public <T extends Mob> T m_21406_(EntityType<T> p_21407_, boolean p_21408_) {
        if (this.m_146910_()) {
-          return (T)null;
-       } else {
-+         var transformReason = this.catserver$transformReason.getAndSet(EntityTransformEvent.TransformReason.UNKNOWN);
-+         var spawnReason = this.catserver$spawnReason.getAndSet(CreatureSpawnEvent.SpawnReason.DEFAULT);
-          T t = p_21407_.m_20615_(this.f_19853_);
-          t.m_20359_(this);
-          t.m_6863_(this.m_6162_());
-@@ -1147,8 +_,12 @@
-                }
+@@ -1148,7 +_,14 @@
              }
           }
--
+ 
 -         this.f_19853_.m_7967_(t);
++         var transformReason = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureMob$convertTo$transformReason();
++         var spawnReason = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureMob$convertTo$spawnReason();
 +         // CraftBukkit start
 +         if (CraftEventFactory.callEntityTransformEvent(this, t, transformReason).isCancelled()) {
 +            return null;

--- a/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/item/ItemEntity.java.patch
@@ -90,7 +90,7 @@
  
           this.f_19812_ |= this.m_20073_();
           if (!this.f_19853_.f_46443_) {
-@@ -146,7 +_,20 @@
+@@ -146,7 +_,23 @@
              }
           }
  
@@ -98,17 +98,20 @@
 +         ItemStack item = this.m_32055_();
 +         if (!this.f_19853_.f_46443_ && this.f_31985_ >= /*lifespan*/f_19853_.spigotConfig.itemDespawnRate) { // Spigot
 +             int hook = net.minecraftforge.event.ForgeEventFactory.onItemExpire(this, item);
-+             if (hook < 0) this.m_146870_();
-+             else          this.lifespan += hook;
++             if (hook < 0) {
++                // CraftBukkit start - fire ItemDespawnEvent
++                if (org.bukkit.craftbukkit.v1_18_R2.event.CraftEventFactory.callItemDespawnEvent(this).isCancelled()) {
++                   this.f_31985_ = 0;
++                   return;
++                }
++                // CraftBukkit end
++                this.m_146870_();
++             } else {
++                this.lifespan += hook;
++             }
 +         }
 +
 +         if (item.m_41619_()) {
-+            // CraftBukkit start - fire ItemDespawnEvent
-+            if (org.bukkit.craftbukkit.v1_18_R2.event.CraftEventFactory.callItemDespawnEvent(this).isCancelled()) {
-+               this.f_31985_ = 0;
-+               return;
-+            }
-+            // CraftBukkit end
              this.m_146870_();
           }
  

--- a/patches/minecraft/net/minecraft/world/entity/monster/ZombieVillager.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/monster/ZombieVillager.java.patch
@@ -39,7 +39,7 @@
  
     public ZombieVillager(EntityType<? extends ZombieVillager> p_34368_, Level p_34369_) {
        super(p_34368_, p_34369_);
-@@ -126,8 +_,12 @@
+@@ -126,13 +_,18 @@
     public void m_8119_() {
        if (!this.f_19853_.f_46443_ && this.m_6084_() && this.m_34408_()) {
           int i = this.m_34410_();
@@ -53,6 +53,12 @@
              this.m_34398_((ServerLevel)this.f_19853_);
           }
        }
+ 
+       super.m_8119_();
++      this.lastTick = MinecraftServer.currentTick; // CraftBukkit
+    }
+ 
+    public InteractionResult m_6071_(Player p_34394_, InteractionHand p_34395_) {
 @@ -169,12 +_,14 @@
        return this.m_20088_().m_135370_(f_34359_);
     }

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -783,22 +783,25 @@
        this.f_36078_ += p_36276_;
        if (this.f_36078_ < 0) {
           this.f_36078_ = 0;
-@@ -1581,14 +_,27 @@
+@@ -1581,14 +_,31 @@
        }
     }
  
 +   // CatServer start
-+   private AtomicReference<EntityExhaustionEvent.ExhaustionReason> catserver$causeFoodReason = new AtomicReference<>(EntityExhaustionEvent.ExhaustionReason.UNKNOWN);
 +   public void causeFoodExhaustion(float p_36400_, EntityExhaustionEvent.ExhaustionReason reason) {
-+      this.catserver$causeFoodReason.set(reason);
-+      this.m_36399_(p_36400_);
++      try {
++         catserver.server.CatServerCaptures.getCatServerCaptures().capturePlayer$causeFoodExhaustion$reason(reason);
++         this.m_36399_(p_36400_);
++      } finally {
++         catserver.server.CatServerCaptures.getCatServerCaptures().getCapturePlayer$causeFoodExhaustion$reason();
++      }
 +   }
 +
     public void m_36399_(float p_36400_) {
        if (!this.f_36077_.f_35934_) {
           if (!this.f_19853_.f_46443_) {
 -            this.f_36097_.m_38703_(p_36400_);
-+            var reason = this.catserver$causeFoodReason.getAndSet(EntityExhaustionEvent.ExhaustionReason.UNKNOWN);
++            var reason = catserver.server.CatServerCaptures.getCatServerCaptures().getCapturePlayer$causeFoodExhaustion$reason();
 +            // CraftBukkit start
 +            EntityExhaustionEvent event = CraftEventFactory.callPlayerExhaustionEvent(this, reason, p_36400_);
 +            if (!event.isCancelled()) {
@@ -806,7 +809,7 @@
 +            }
 +            // CraftBukkit end
           }
--
+ 
        }
     }
 +   // CatServer end

--- a/patches/minecraft/net/minecraft/world/entity/projectile/ThrownPotion.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/projectile/ThrownPotion.java.patch
@@ -54,7 +54,7 @@
              if (livingentity.m_5801_()) {
                 double d0 = this.m_20280_(livingentity);
                 if (d0 < 16.0D) {
-@@ -134,22 +_,47 @@
+@@ -134,22 +_,48 @@
                       d1 = 1.0D;
                    }
  
@@ -83,6 +83,7 @@
 +
 +      org.bukkit.event.entity.PotionSplashEvent event = CraftEventFactory.callPotionSplashEvent(this, affected);
 +      if (!event.isCancelled() && list != null && !list.isEmpty()) { // do not process effects if there are no effects to process
++         Entity entity1 = this.m_150173_();
 +         for (org.bukkit.entity.LivingEntity victim : event.getAffectedEntities()) {
 +            if (!(victim instanceof CraftLivingEntity)) {
 +               continue;
@@ -109,7 +110,7 @@
 +               } else {
 +                  int i = (int) (intensity * (double) effectinstance.m_19557_() + 0.5D);
 +                  if (i > 20) {
-+                     livingentity.addEffect(new MobEffectInstance(effect, i, effectinstance.m_19564_(), effectinstance.m_19571_(), effectinstance.m_19572_()), EntityPotionEffectEvent.Cause.POTION_SPLASH); // CraftBukkit
++                     livingentity.addEffect(new MobEffectInstance(effect, i, effectinstance.m_19564_(), effectinstance.m_19571_(), effectinstance.m_19572_()), entity1, EntityPotionEffectEvent.Cause.POTION_SPLASH); // CraftBukkit
 +                  }
 +               }
 +            }

--- a/patches/minecraft/net/minecraft/world/entity/raid/Raid.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/raid/Raid.java.patch
@@ -55,10 +55,18 @@
  
              ++this.f_37673_;
              if (this.f_37673_ >= 48000L) {
-+               org.bukkit.craftbukkit.v1_18_R2.event.CraftEventFactory.callRaidStopEvent(this, org.bukkit.event.raid.RaidStopEvent.Reason.UNSPAWNABLE);  // CraftBukkit
++               org.bukkit.craftbukkit.v1_18_R2.event.CraftEventFactory.callRaidStopEvent(this, org.bukkit.event.raid.RaidStopEvent.Reason.TIMEOUT);  // CraftBukkit
                 this.m_37774_();
                 return;
              }
+@@ -345,6 +_,7 @@
+                }
+ 
+                if (k > 3) {
++                  org.bukkit.craftbukkit.v1_18_R2.event.CraftEventFactory.callRaidStopEvent(this, org.bukkit.event.raid.RaidStopEvent.Reason.UNSPAWNABLE);  // CraftBukkit
+                   this.m_37774_();
+                   break;
+                }
 @@ -355,7 +_,7 @@
                    ++this.f_37683_;
                 } else {

--- a/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecart.java.patch
@@ -251,7 +251,7 @@
        if (!this.f_19861_) {
 -         this.m_20256_(this.m_20184_().m_82490_(0.95D));
 +         // CraftBukkit start - replace magic numbers with our variables
-+         this.m_20256_(new Vec3(this.m_20184_().f_82479_ * this.flyingX, this.m_20184_().f_82480_ * this.flyingY, this.m_20184_().f_82481_ * this.flyingZ));
++         this.m_20256_(new Vec3(this.m_20184_().f_82479_ * this.flyingX, this.m_20184_().f_82480_ * this.flyingY, this.m_20184_().f_82481_ * this.flyingZ).m_82490_(getDragAir()));
 +         // CraftBukkit end
        }
  

--- a/patches/minecraft/net/minecraft/world/inventory/ChestMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/ChestMenu.java.patch
@@ -48,7 +48,7 @@
 +         return bukkitEntity;
 +      }
 +      CraftInventory inventory;
-+      if (this.f_39221_ instanceof PlayerInventory) {
++      if (this.f_39221_ instanceof Inventory) {
 +         inventory = new org.bukkit.craftbukkit.v1_18_R2.inventory.CraftInventoryPlayer((Inventory) this.f_39221_);
 +      } else if (this.f_39221_ instanceof CompoundContainer) {
 +         inventory = new org.bukkit.craftbukkit.v1_18_R2.inventory.CraftInventoryDoubleChest((CompoundContainer) this.f_39221_);

--- a/patches/minecraft/net/minecraft/world/inventory/EnchantmentMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/EnchantmentMenu.java.patch
@@ -71,7 +71,8 @@
 -         if (!itemstack.m_41619_() && itemstack.m_41792_()) {
 +         if (!itemstack.m_41619_()) {  // CraftBukkit - relax condition
              this.f_39450_.m_39292_((p_39485_, p_39486_) -> {
-                int j = 0;
+-               int j = 0;
++               float j = 0;
  
                 for(BlockPos blockpos : EnchantmentTableBlock.f_207902_) {
                    if (EnchantmentTableBlock.m_207909_(p_39485_, p_39486_, blockpos)) {
@@ -105,15 +106,15 @@
 +                  org.bukkit.enchantments.Enchantment enchantment = (this.f_39447_[k] >= 0) ? org.bukkit.enchantments.Enchantment.getByKey(CraftNamespacedKey.fromMinecraft(Registry.f_122825_.m_7981_(Registry.f_122825_.m_7942_(this.f_39447_[k])))) : null;
 +                  offers[k] = (enchantment != null) ? new EnchantmentOffer(enchantment, this.f_39448_[k], this.f_39446_[k]) : null;
 +               }
-+               PrepareItemEnchantEvent event = new PrepareItemEnchantEvent(player, this.getBukkitView(), f_39450_.getLocation().getBlock(), item, offers, j);
++               PrepareItemEnchantEvent event = new PrepareItemEnchantEvent(player, this.getBukkitView(), f_39450_.getLocation().getBlock(), item, offers, (int) j);
 +               event.setCancelled(!itemstack.m_41792_());
 +               if (this.getBukkitView() != null) // CatServer - Bypass call event if Bukkit view is null (mod custom container)
 +               p_39485_.getCraftServer().getPluginManager().callEvent(event);
 +               if (event.isCancelled()) {
-+                  for (j = 0; j < 3; ++j) {
-+                     this.f_39446_[j] = 0;
-+                     this.f_39447_[j] = -1;
-+                     this.f_39448_[j] = -1;
++                  for (int k = 0; k < 3; ++k) {
++                     this.f_39446_[k] = 0;
++                     this.f_39447_[k] = -1;
++                     this.f_39448_[k] = -1;
 +                  }
 +                  return;
 +               }

--- a/patches/minecraft/net/minecraft/world/item/ArmorItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ArmorItem.java.patch
@@ -23,11 +23,11 @@
 +            world.getCraftServer().getPluginManager().callEvent(event);
 +         }
 +         if (event.isCancelled()) {
-+            itemstack.m_41769_(1);
++            p_40400_.m_41769_(1);
 +            return false;
 +         }
 +         if (!event.getItem().equals(craftItem)) {
-+            itemstack.m_41769_(1);
++            p_40400_.m_41769_(1);
 +            // Chain to handler for new item
 +            ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
 +            DispenseItemBehavior idispensebehavior = (DispenseItemBehavior) DispenserBlock.f_52661_.get(eventStack.m_41720_());

--- a/patches/minecraft/net/minecraft/world/level/BaseSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/BaseSpawner.java.patch
@@ -33,7 +33,7 @@
     }
  
     private boolean m_151343_(Level p_151344_, BlockPos p_151345_) {
-@@ -125,16 +_,26 @@
+@@ -125,16 +_,38 @@
                    entity.m_7678_(entity.m_20185_(), entity.m_20186_(), entity.m_20189_(), p_151312_.f_46441_.nextFloat() * 360.0F, 0.0F);
                    if (entity instanceof Mob) {
                       Mob mob = (Mob)entity;
@@ -48,13 +48,26 @@
 +                        if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(mob, (LevelAccessor)p_151312_, (float)entity.m_20185_(), (float)entity.m_20186_(), (float)entity.m_20189_(), this, MobSpawnType.SPAWNER))
                          ((Mob)entity).m_6518_(p_151312_, p_151312_.m_6436_(entity.m_142538_()), MobSpawnType.SPAWNER, (SpawnGroupData)null, (CompoundTag)null);
                       }
+-                  }
 +                     // Spigot Start
 +                     if ( mob.f_19853_.spigotConfig.nerfSpawnerMobs )
 +                     {
 +                        mob.aware = false;
 +                     }
 +                     // Spigot End
-                   }
++                  }
++                  // Spigot Start
++                  if (org.bukkit.craftbukkit.v1_18_R2.event.CraftEventFactory.callSpawnerSpawnEvent(entity, p_151313_).isCancelled()) {
++                     Entity vehicle = entity.m_20202_();
++                     if (vehicle != null) {
++                        vehicle.m_146870_();
++                     }
++                     for (Entity passenger : entity.m_146897_()) {
++                        passenger.m_146870_();
++                     }
++                     continue;
++                  }
++                  // Spigot End
  
 -                  if (!p_151312_.m_8860_(entity)) {
 +                  if (!p_151312_.tryAddFreshEntityWithPassengers(entity, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.SPAWNER)) { // CraftBukkit

--- a/patches/minecraft/net/minecraft/world/level/NaturalSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/NaturalSpawner.java.patch
@@ -70,10 +70,10 @@
 +                           // CraftBukkit start
 +                           // CatServer - fix Botania mixin injection
 +                           try {
-+                              catserver.server.CatServerCaptures.getCatServerCaptures().captureNaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason((mob instanceof net.minecraft.world.entity.animal.Ocelot && !((org.bukkit.entity.Ageable) mob.getBukkitEntity()).isAdult()) ? SpawnReason.OCELOT_BABY : SpawnReason.NATURAL);
++                              catserver.server.CatServerCaptures.getCatServerCaptures().captureServerLevelAccessor$addFreshEntityWithPassengers$reason((mob instanceof net.minecraft.world.entity.animal.Ocelot && !((org.bukkit.entity.Ageable) mob.getBukkitEntity()).isAdult()) ? SpawnReason.OCELOT_BABY : SpawnReason.NATURAL);
 +                              p_47040_.m_47205_(mob);
 +                           } finally {
-+                              catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureNaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason(); // CatServer - Make sure reset
++                              catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureServerLevelAccessor$addFreshEntityWithPassengers$reason(); // CatServer - Make sure reset
 +                           }
 +                           // CatServer end
 +                           if (!mob.m_146910_()) {

--- a/patches/minecraft/net/minecraft/world/level/NaturalSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/NaturalSpawner.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/NaturalSpawner.java
 +++ b/net/minecraft/world/level/NaturalSpawner.java
-@@ -44,9 +_,14 @@
+@@ -44,9 +_,15 @@
  import net.minecraft.world.level.levelgen.structure.BuiltinStructures;
  import net.minecraft.world.level.material.FluidState;
  import net.minecraft.world.level.pathfinder.PathComputationType;
@@ -9,6 +9,7 @@
 +import org.bukkit.craftbukkit.v1_18_R2.util.CraftSpawnCategory;
 +import org.bukkit.entity.SpawnCategory;
 +import org.bukkit.event.entity.CreatureSpawnEvent;
++import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
  import org.slf4j.Logger;
  
 +// TODO: ForgeHooks.canEntitySpawn
@@ -52,7 +53,7 @@
        p_47030_.m_46473_().m_7238_();
     }
  
-@@ -179,13 +_,23 @@
+@@ -179,13 +_,26 @@
                          }
  
                          mob.m_7678_(d0, (double)i, d1, p_47040_.f_46441_.nextFloat() * 360.0F, 0.0F);
@@ -63,13 +64,17 @@
                             spawngroupdata = mob.m_6518_(p_47040_, p_47040_.m_6436_(mob.m_142538_()), MobSpawnType.NATURAL, spawngroupdata, (CompoundTag)null);
 -                           ++j;
 -                           ++l1;
-+                           // CraftBukkit start
-+                           // CatServer - fix Botania mixin injection
-+                           catserver.server.CatServerCaptures.getCatServerCaptures().captureSpawnReason(CreatureSpawnEvent.SpawnReason.NATURAL);
-                            p_47040_.m_47205_(mob);
+-                           p_47040_.m_47205_(mob);
 -                           p_47044_.m_47100_(mob, p_47041_);
 -                           if (j >= mob.m_5792_()) {
-+                           catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureSpawnReason(); // CatServer - Make sure reset
++                           // CraftBukkit start
++                           // CatServer - fix Botania mixin injection
++                           try {
++                              catserver.server.CatServerCaptures.getCatServerCaptures().captureNaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason((mob instanceof net.minecraft.world.entity.animal.Ocelot && !((org.bukkit.entity.Ageable) mob.getBukkitEntity()).isAdult()) ? SpawnReason.OCELOT_BABY : SpawnReason.NATURAL);
++                              p_47040_.m_47205_(mob);
++                           } finally {
++                              catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureNaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason(); // CatServer - Make sure reset
++                           }
 +                           // CatServer end
 +                           if (!mob.m_146910_()) {
 +                              ++j;

--- a/patches/minecraft/net/minecraft/world/level/ServerLevelAccessor.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/ServerLevelAccessor.java.patch
@@ -1,13 +1,14 @@
 --- a/net/minecraft/world/level/ServerLevelAccessor.java
 +++ b/net/minecraft/world/level/ServerLevelAccessor.java
-@@ -7,6 +_,17 @@
+@@ -7,6 +_,18 @@
     ServerLevel m_6018_();
  
     default void m_47205_(Entity p_47206_) {
 -      p_47206_.m_142428_().forEach(this::m_7967_);
 -   }
++      org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureNaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason();
 +      // CraftBukkit start
-+      this.addFreshEntityWithPassengers(p_47206_, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT);
++      this.addFreshEntityWithPassengers(p_47206_, reason);
 +   }
 +
 +   default void addFreshEntityWithPassengers(Entity entity, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason) {

--- a/patches/minecraft/net/minecraft/world/level/ServerLevelAccessor.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/ServerLevelAccessor.java.patch
@@ -6,7 +6,7 @@
     default void m_47205_(Entity p_47206_) {
 -      p_47206_.m_142428_().forEach(this::m_7967_);
 -   }
-+      org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureNaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason();
++      org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureServerLevelAccessor$addFreshEntityWithPassengers$reason();
 +      // CraftBukkit start
 +      this.addFreshEntityWithPassengers(p_47206_, reason);
 +   }

--- a/patches/minecraft/net/minecraft/world/level/block/BigDripleafBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/BigDripleafBlock.java.patch
@@ -72,7 +72,7 @@
  
     private static void m_152313_(BlockState p_152314_, Level p_152315_, BlockPos p_152316_) {
 -      m_152277_(p_152314_, p_152315_, p_152316_, Tilt.NONE);
-+      setTilt(p_152314_, p_152315_, p_152316_, Tilt.NONE, null); // CraftBukkit
++      setTilt(p_152314_, p_152315_, p_152316_, Tilt.NONE, (Entity)null); // CraftBukkit
        if (p_152314_.m_61143_(f_152201_) != Tilt.NONE) {
           m_152232_(p_152315_, p_152316_, SoundEvents.f_144132_);
        }
@@ -80,7 +80,7 @@
     }
  
     private static void m_152277_(BlockState p_152278_, Level p_152279_, BlockPos p_152280_, Tilt p_152281_) {
-+      m_152277_(p_152278_, p_152279_, p_152280_, p_152281_); // CatServer
++      setTilt(p_152278_, p_152279_, p_152280_, p_152281_, (Entity)null); // CatServer
 +   }
 +
 +   private static boolean setTilt(BlockState p_152278_, Level p_152279_, BlockPos p_152280_, Tilt p_152281_, @Nullable Entity entity) {

--- a/patches/minecraft/net/minecraft/world/level/block/CommandBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/CommandBlock.java.patch
@@ -15,10 +15,10 @@
 +            // CraftBukkit start
 +            org.bukkit.block.Block bukkitBlock = p_51839_.getWorld().getBlockAt(p_51840_.m_123341_(), p_51840_.m_123342_(), p_51840_.m_123343_());
 +            int old = flag1 ? 15 : 0;
-+            int current = flag1 ? 15 : 0;
++            int current = flag ? 15 : 0;
 +            BlockRedstoneEvent eventRedstone = new BlockRedstoneEvent(bukkitBlock, old, current);
 +            p_51839_.getCraftServer().getPluginManager().callEvent(eventRedstone);
-+            flag1 = eventRedstone.getNewCurrent() > 0;
++            flag = eventRedstone.getNewCurrent() > 0;
 +            // CraftBukkit end
              commandblockentity.m_59135_(flag);
              if (!flag1 && !commandblockentity.m_59143_() && commandblockentity.m_59148_() != CommandBlockEntity.Mode.SEQUENCE) {

--- a/patches/minecraft/net/minecraft/world/level/block/FireBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/FireBlock.java.patch
@@ -21,7 +21,7 @@
 +      // CraftBukkit start
 +      if (!this.m_7898_(p_53458_, p_53461_, p_53462_)) {
 +         // Suppress during worldgen
-+         if (!(p_53461_ instanceof World)) {
++         if (!(p_53461_ instanceof Level)) {
 +            return Blocks.f_50016_.m_49966_();
 +         }
 +         CraftBlockState blockState = CraftBlockStates.getBlockState(p_53461_, p_53462_);

--- a/patches/minecraft/net/minecraft/world/level/block/MushroomBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/MushroomBlock.java.patch
@@ -40,7 +40,7 @@
 +      if (event.getResult().equals(net.minecraftforge.eventbus.api.Event.Result.DENY)) return false;
        p_54860_.m_7471_(p_54861_, false);
 -      if (this.f_153981_.get().m_203334_().m_65385_(p_54860_, p_54860_.m_7726_().m_8481_(), p_54863_, p_54861_)) {
-+      SaplingBlock.treeType = (this == Blocks.f_50072_) ? TreeType.BROWN_MUSHROOM : TreeType.BROWN_MUSHROOM; // CraftBukkit
++      SaplingBlock.treeType = (this == Blocks.f_50072_) ? TreeType.BROWN_MUSHROOM : TreeType.RED_MUSHROOM; // CraftBukkit // CatServer - BROWN_MUSHROOM -> RED_MUSHROOM craftbukkit fixed in higher versions
 +      if (event.getFeature().m_203334_().m_65385_(p_54860_, p_54860_.m_7726_().m_8481_(), p_54863_, p_54861_)) {
           return true;
        } else {

--- a/patches/minecraft/net/minecraft/world/level/block/RedStoneOreBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/RedStoneOreBlock.java.patch
@@ -48,24 +48,25 @@
        }
  
        ItemStack itemstack = p_55475_.m_21120_(p_55476_);
-@@ -52,7 +_,17 @@
- 
-    private static void m_55492_(BlockState p_55493_, Level p_55494_, BlockPos p_55495_) {
-       m_55454_(p_55494_, p_55495_);
-+      p_55494_.m_7731_(p_55495_, p_55493_.m_61124_(f_55450_, Boolean.valueOf(true)), 3);
+@@ -55,7 +_,18 @@
+       if (!p_55493_.m_61143_(f_55450_)) {
+          p_55494_.m_7731_(p_55495_, p_55493_.m_61124_(f_55450_, Boolean.valueOf(true)), 3);
+       }
 +   }
-+
+ 
 +   private static void interact(BlockState p_55493_, Level p_55494_, BlockPos p_55495_, Entity entity) { // CraftBukkit - add Entity
 +      m_55454_(p_55494_, p_55495_);
-       if (!p_55493_.m_61143_(f_55450_)) {
++      if (!p_55493_.m_61143_(f_55450_)) {
 +         // CraftBukkit start
 +         if (CraftEventFactory.callEntityChangeBlockEvent(entity, p_55495_, p_55493_.m_61124_(f_55450_, true)).isCancelled()) {
 +            return;
 +         }
 +         // CraftBukkit end
-          p_55494_.m_7731_(p_55495_, p_55493_.m_61124_(f_55450_, Boolean.valueOf(true)), 3);
-       }
++         p_55494_.m_7731_(p_55495_, p_55493_.m_61124_(f_55450_, Boolean.valueOf(true)), 3);
++      }
+    }
  
+    public boolean m_6724_(BlockState p_55486_) {
 @@ -64,6 +_,11 @@
  
     public void m_7455_(BlockState p_55488_, ServerLevel p_55489_, BlockPos p_55490_, Random p_55491_) {

--- a/patches/minecraft/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -217,7 +217,7 @@
  
           if (itemstack.m_150930_(Blocks.f_50057_.m_5456_()) && !p_155028_.get(1).m_41619_() && p_155028_.get(1).m_150930_(Items.f_42446_)) {
              p_155028_.set(1, new ItemStack(Items.f_42447_));
-@@ -331,13 +_,14 @@
+@@ -331,22 +_,23 @@
           return false;
        }
     }
@@ -233,7 +233,9 @@
        }
     }
  
-@@ -346,7 +_,7 @@
+    private static int m_155009_(Level p_155010_, RecipeType<? extends AbstractCookingRecipe> p_155011_, Container p_155012_) {
+-      return p_155010_.m_7465_().m_44015_((RecipeType<AbstractCookingRecipe>)p_155011_, p_155012_, p_155010_).map(AbstractCookingRecipe::m_43753_).orElse(200);
++      return (p_155010_ != null) ? p_155010_.m_7465_().m_44015_((RecipeType<AbstractCookingRecipe>)p_155011_, p_155012_, p_155010_).map(AbstractCookingRecipe::m_43753_).orElse(200) : 200; // CraftBukkit - SPIGOT-4302 // Eclipse fail
     }
  
     public static boolean m_58399_(ItemStack p_58400_) {

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BeaconBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BeaconBlockEntity.java.patch
@@ -95,7 +95,7 @@
 +   private static void applyEffect(List<Player> list, MobEffect p_155101_, int j, int i) {
 +      {
 +         for (Player player : list) {
-+            player.m_7292_(new MobEffectInstance(p_155101_, j, i, true, true));
++            player.addEffect(new MobEffectInstance(p_155101_, j, i, true, true), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.BEACON);
 +         }
 +      }
 +   }
@@ -113,7 +113,20 @@
     private static void m_155097_(Level p_155098_, BlockPos p_155099_, int p_155100_, @Nullable MobEffect p_155101_, @Nullable MobEffect p_155102_) {
        if (!p_155098_.f_46443_ && p_155101_ != null) {
           double d0 = (double)(p_155100_ * 10 + 10);
-@@ -233,6 +_,7 @@
+@@ -222,17 +_,18 @@
+          List<Player> list = p_155098_.m_45976_(Player.class, aabb);
+ 
+          for(Player player : list) {
+-            player.m_7292_(new MobEffectInstance(p_155101_, j, i, true, true));
++            player.addEffect(new MobEffectInstance(p_155101_, j, i, true, true), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.BEACON);
+          }
+ 
+          if (p_155100_ >= 4 && p_155101_ != p_155102_ && p_155102_ != null) {
+             for(Player player1 : list) {
+-               player1.m_7292_(new MobEffectInstance(p_155102_, j, 0, true, true));
++               player1.addEffect(new MobEffectInstance(p_155102_, j, 0, true, true), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.BEACON);
+             }
+          }
  
        }
     }

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BeehiveBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BeehiveBlockEntity.java.patch
@@ -36,14 +36,18 @@
                    } else {
                       bee.m_27915_(400);
                    }
-@@ -95,10 +_,16 @@
+@@ -95,10 +_,20 @@
  
     }
  
 +   private boolean catserver$isForceReleaseAllOccupants = false;
 +   public List<Entity> releaseBees(BlockState p_58760_, BeehiveBlockEntity.BeeReleaseStatus p_58761_, boolean force) {
-+      this.catserver$isForceReleaseAllOccupants = force;
-+      return m_58759_(p_58760_, p_58761_);
++      try {
++         this.catserver$isForceReleaseAllOccupants = force;
++         return m_58759_(p_58760_, p_58761_);
++      } finally {
++         this.catserver$isForceReleaseAllOccupants = false;
++      }
 +   }
 +
     private List<Entity> m_58759_(BlockState p_58760_, BeehiveBlockEntity.BeeReleaseStatus p_58761_) {
@@ -75,15 +79,19 @@
           p_58745_.m_8127_();
           p_58745_.m_20153_();
           CompoundTag compoundtag = new CompoundTag();
-@@ -153,8 +_,15 @@
+@@ -153,8 +_,19 @@
        this.f_58732_.add(new BeehiveBlockEntity.BeeData(p_155158_, p_155159_, p_155160_ ? 2400 : 600));
     }
  
-+   // CatServer start
-+   private static boolean catserver$isForceReleaseOccupant;
++   // CatServer start - This allows us to bypass the night/rain/emergency check
++   private static boolean catserver$isForceReleaseOccupant = false;
 +   private static boolean releaseBee(Level p_155137_, BlockPos p_155138_, BlockState p_155139_, BeehiveBlockEntity.BeeData p_155140_, @Nullable List<Entity> p_155141_, BeehiveBlockEntity.BeeReleaseStatus p_155142_, @Nullable BlockPos p_155143_, boolean force) {
-+      BeehiveBlockEntity.catserver$isForceReleaseOccupant = force;
-+      return m_155136_(p_155137_, p_155138_, p_155139_, p_155140_, p_155141_, p_155142_, p_155143_);
++      try {
++         BeehiveBlockEntity.catserver$isForceReleaseOccupant = force;
++         return m_155136_(p_155137_, p_155138_, p_155139_, p_155140_, p_155141_, p_155142_, p_155143_);
++      } finally {
++         BeehiveBlockEntity.catserver$isForceReleaseOccupant = false;
++      }
 +   }
 +
     private static boolean m_155136_(Level p_155137_, BlockPos p_155138_, BlockState p_155139_, BeehiveBlockEntity.BeeData p_155140_, @Nullable List<Entity> p_155141_, BeehiveBlockEntity.BeeReleaseStatus p_155142_, @Nullable BlockPos p_155143_) {

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -132,15 +132,18 @@
        if (itemstack.m_41619_()) {
           return false;
        } else if (!PotionBrewing.m_43506_(itemstack)) {
-@@ -164,26 +_,50 @@
+@@ -164,26 +_,70 @@
        }
     }
  
 +   // CatServer start
-+   private static AtomicReference<BrewingStandBlockEntity> catserver$captureBrewBlockEntity = new AtomicReference<>();
 +   private static void doBrew(Level p_155291_, BlockPos p_155292_, NonNullList<ItemStack> p_155293_, BrewingStandBlockEntity blockEntity) {
-+      BrewingStandBlockEntity.catserver$captureBrewBlockEntity.set(blockEntity);
-+      BrewingStandBlockEntity.m_155290_(p_155291_, p_155292_, p_155293_);
++      try {
++         catserver.server.CatServerCaptures.getCatServerCaptures().captureBrewingStandBlockEntity$doBrew$brewingStandBlockEntity(blockEntity);
++         BrewingStandBlockEntity.m_155290_(p_155291_, p_155292_, p_155293_);
++      } finally {
++         catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureBrewingStandBlockEntity$doBrew$brewingStandBlockEntity();
++      }
 +   }
 +
     private static void m_155290_(Level p_155291_, BlockPos p_155292_, NonNullList<ItemStack> p_155293_) {
@@ -150,11 +153,25 @@
 -      for(int i = 0; i < 3; ++i) {
 -         p_155293_.set(i, PotionBrewing.m_43529_(itemstack, p_155293_.get(i)));
 -      }
-+      var tileentitybrewingstand = catserver$captureBrewBlockEntity.getAndSet(null);
-+      InventoryHolder owner = tileentitybrewingstand.getOwner();
+-
+-      itemstack.m_41774_(1);
+-      if (itemstack.m_41720_().m_41470_()) {
+-         ItemStack itemstack1 = new ItemStack(itemstack.m_41720_().m_41469_());
++      net.minecraftforge.common.brewing.BrewingRecipeRegistry.brewPotions(p_155293_, itemstack, f_58974_);
++      net.minecraftforge.event.ForgeEventFactory.onPotionBrewed(p_155293_);
++
++      var tileentitybrewingstand = catserver.server.CatServerCaptures.getCatServerCaptures().getCaptureBrewingStandBlockEntity$doBrew$brewingStandBlockEntity(); // CatServer
++
++      InventoryHolder owner = tileentitybrewingstand == null ? null : tileentitybrewingstand.getOwner(); // CatServer
 +      List<org.bukkit.inventory.ItemStack> brewResults = new ArrayList<>(3);
 +      for (int i = 0; i < 3; ++i) {
-+         brewResults.add(i, CraftItemStack.asCraftMirror(PotionBrewing.m_43529_(itemstack, (ItemStack) p_155293_.get(i))));
++         // CatServer start
++         if (i < p_155293_.size()) {
++            brewResults.add(i, CraftItemStack.asCraftMirror(p_155293_.get(i)));
++         } else {
++            brewResults.add(i, CraftItemStack.asCraftMirror(ItemStack.f_41583_));
++         }
++         // CatServer end
 +      }
 +      if (owner != null) {
 +         BrewEvent event = new BrewEvent(CraftBlock.at(p_155291_, p_155292_), (org.bukkit.inventory.BrewerInventory) owner.getInventory(), brewResults, tileentitybrewingstand.f_58979_);
@@ -164,13 +181,17 @@
 +         }
 +      }
 +      // CraftBukkit end
- 
--      itemstack.m_41774_(1);
--      if (itemstack.m_41720_().m_41470_()) {
--         ItemStack itemstack1 = new ItemStack(itemstack.m_41720_().m_41469_());
-+      net.minecraftforge.common.brewing.BrewingRecipeRegistry.brewPotions(p_155293_, itemstack, f_58974_);
-+      net.minecraftforge.event.ForgeEventFactory.onPotionBrewed(p_155293_);
-+      // CatServer TODO: missing BrewEvent result
++
++      for (int i = 0; i < 3; ++i) {
++         // CraftBukkit start - validate index in case it is cleared by plugins
++         if (i < brewResults.size()) {
++            p_155293_.set(i, CraftItemStack.asNMSCopy(brewResults.get(i)));
++         } else {
++            p_155293_.set(i, ItemStack.f_41583_);
++         }
++         // CraftBukkit end
++      }
++
 +      if (itemstack.hasContainerItem()) {
 +         ItemStack itemstack1 = itemstack.getContainerItem();
 +         itemstack.m_41774_(1);

--- a/patches/minecraft/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
@@ -144,7 +144,7 @@
 +                     return false;
 +                  }
 +                  int origCount = event.getItem().getAmount(); // Spigot
-+                  ItemStack itemstack1 = m_59326_(p_155566_, p_155566_, CraftItemStack.asNMSCopy(event.getItem()), direction);
++                  ItemStack itemstack1 = m_59326_(p_155566_, container, CraftItemStack.asNMSCopy(event.getItem()), direction);
 +                  // CraftBukkit end
                    if (itemstack1.m_41619_()) {
                       container.m_6596_();
@@ -176,10 +176,10 @@
     private static boolean m_59354_(Hopper p_59355_, Container p_59356_, int p_59357_, Direction p_59358_) {
 +      // CatServer start
 +      Level level;
-+      if (p_59355_ instanceof HopperBlockEntity) {
-+         level = ((HopperBlockEntity) p_59355_).f_58857_;
-+      } else if (p_59355_ instanceof MinecartHopper) {
-+         level = ((MinecartHopper) p_59355_).f_19853_;
++      if (p_59355_ instanceof net.minecraft.world.level.block.entity.BlockEntity) {
++         level = ((net.minecraft.world.level.block.entity.BlockEntity) p_59355_).f_58857_;
++      } else if (p_59355_ instanceof net.minecraft.world.entity.Entity) {
++         level = ((net.minecraft.world.entity.Entity) p_59355_).f_19853_;
 +      } else {
 +         level = net.minecraft.server.MinecraftServer.getServer().m_129783_();
 +      }

--- a/patches/minecraft/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
@@ -69,7 +69,7 @@
           int j = 0;
  
 +         // CraftBukkit start
-+         final org.bukkit.block.Block bblock = p_60182_.getWorld().getBlockAt(blockpos.m_123341_(), blockpos.m_123342_(), blockpos.m_123343_());
++         final org.bukkit.block.Block bblock = p_60182_.getWorld().getBlockAt(p_60183_.m_123341_(), p_60183_.m_123342_(), p_60183_.m_123343_());
 +         final List<BlockPos> moved = pistonstructureresolver.m_60436_();
 +         final List<BlockPos> broken = pistonstructureresolver.m_60437_();
 +         List<org.bukkit.block.Block> blocks = new AbstractList<org.bukkit.block.Block>() {
@@ -91,9 +91,9 @@
 +         };
 +         org.bukkit.event.block.BlockPistonEvent event;
 +         if (p_60185_) {
-+            event = new BlockPistonExtendEvent(bblock, blocks, CraftBlock.notchToBlockFace(p_60184_));
++            event = new BlockPistonExtendEvent(bblock, blocks, CraftBlock.notchToBlockFace(direction));
 +         } else {
-+            event = new BlockPistonRetractEvent(bblock, blocks, CraftBlock.notchToBlockFace(p_60184_));
++            event = new BlockPistonRetractEvent(bblock, blocks, CraftBlock.notchToBlockFace(direction));
 +         }
 +         p_60182_.getCraftServer().getPluginManager().callEvent(event);
 +         if (event.isCancelled()) {

--- a/src/main/java/catserver/server/CatServerCaptures.java
+++ b/src/main/java/catserver/server/CatServerCaptures.java
@@ -17,7 +17,7 @@ public class CatServerCaptures {
     private Entity entity = null;
     private ItemEntity itemEntity = null;
     private CreatureSpawnEvent.SpawnReason spawnReason = null;
-    private CreatureSpawnEvent.SpawnReason NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason = CreatureSpawnEvent.SpawnReason.DEFAULT;
+    private CreatureSpawnEvent.SpawnReason ServerLevelAccessor$addFreshEntityWithPassengers$reason = CreatureSpawnEvent.SpawnReason.DEFAULT;
     private boolean doPlace = true;
     private int createPortalRadius = 16;
     private BlockPos blockPos = null;
@@ -205,13 +205,13 @@ public class CatServerCaptures {
         return result;
     }
 
-    public void captureNaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason(CreatureSpawnEvent.SpawnReason NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason) {
-        this.NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason = NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason;
+    public void captureServerLevelAccessor$addFreshEntityWithPassengers$reason(CreatureSpawnEvent.SpawnReason NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason) {
+        this.ServerLevelAccessor$addFreshEntityWithPassengers$reason = NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason;
     }
 
-    public CreatureSpawnEvent.SpawnReason getCaptureNaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason() {
-        var result = this.NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason;
-        this.NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason = CreatureSpawnEvent.SpawnReason.DEFAULT;
+    public CreatureSpawnEvent.SpawnReason getCaptureServerLevelAccessor$addFreshEntityWithPassengers$reason() {
+        var result = this.ServerLevelAccessor$addFreshEntityWithPassengers$reason;
+        this.ServerLevelAccessor$addFreshEntityWithPassengers$reason = CreatureSpawnEvent.SpawnReason.DEFAULT;
         return result;
     }
 }

--- a/src/main/java/catserver/server/CatServerCaptures.java
+++ b/src/main/java/catserver/server/CatServerCaptures.java
@@ -5,7 +5,11 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BrewingStandBlockEntity;
+import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.EntityExhaustionEvent;
+import org.bukkit.event.entity.EntityTransformEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
 public class CatServerCaptures {
@@ -13,6 +17,7 @@ public class CatServerCaptures {
     private Entity entity = null;
     private ItemEntity itemEntity = null;
     private CreatureSpawnEvent.SpawnReason spawnReason = null;
+    private CreatureSpawnEvent.SpawnReason NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason = CreatureSpawnEvent.SpawnReason.DEFAULT;
     private boolean doPlace = true;
     private int createPortalRadius = 16;
     private BlockPos blockPos = null;
@@ -20,6 +25,12 @@ public class CatServerCaptures {
     private Direction direction = null;
     private PlayerTeleportEvent.TeleportCause changeDimCause = PlayerTeleportEvent.TeleportCause.UNKNOWN;
     private PlayerTeleportEvent.TeleportCause teleportCause = PlayerTeleportEvent.TeleportCause.UNKNOWN;
+    private org.bukkit.block.Block ShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlock = null;
+    private CraftItemStack ShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStack = CraftItemStack.asCraftMirror(null);
+    private EntityTransformEvent.TransformReason Mob$convertTo$transformReason = EntityTransformEvent.TransformReason.UNKNOWN;
+    private CreatureSpawnEvent.SpawnReason Mob$convertTo$spawnReason = CreatureSpawnEvent.SpawnReason.DEFAULT;
+    private EntityExhaustionEvent.ExhaustionReason Player$causeFoodExhaustion$reason = EntityExhaustionEvent.ExhaustionReason.UNKNOWN;
+    private BrewingStandBlockEntity BrewingStandBlockEntity$doBrew$brewingStandBlockEntity = null;
 
     public static CatServerCaptures getCatServerCaptures() {
         CatServerCaptures currentThreadCaptures = catServerCaptures.get();
@@ -127,6 +138,80 @@ public class CatServerCaptures {
     public PlayerTeleportEvent.TeleportCause getCaptureChangeDimCause() {
         var result = this.changeDimCause;
         this.changeDimCause = PlayerTeleportEvent.TeleportCause.UNKNOWN;
+        return result;
+    }
+
+    public void captureShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlock(org.bukkit.block.Block ShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlock) {
+        this.ShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlock = ShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlock;
+    }
+
+    public org.bukkit.block.Block getCaptureShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlockWithoutReset() {
+        return this.ShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlock;
+    }
+
+    public void resetCaptureShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlock() {
+        this.ShearsDispenseItemBehavior$tryShearLivingEntity$bukkitBlock = null;
+    }
+
+    public void captureShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStack(CraftItemStack ShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStack) {
+        this.ShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStack = ShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStack;
+    }
+
+    public CraftItemStack getCaptureShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStackWithoutReset() {
+        return this.ShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStack;
+    }
+
+    public void resetCaptureShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStack() {
+        this.ShearsDispenseItemBehavior$tryShearLivingEntity$craftItemStack = CraftItemStack.asCraftMirror(null);
+    }
+
+    public void captureMob$convertTo$transformReason(EntityTransformEvent.TransformReason Mob$convertTo$transformReason) {
+        this.Mob$convertTo$transformReason = Mob$convertTo$transformReason;
+    }
+
+    public EntityTransformEvent.TransformReason getCaptureMob$convertTo$transformReason() {
+        var result = this.Mob$convertTo$transformReason;
+        this.Mob$convertTo$transformReason = EntityTransformEvent.TransformReason.UNKNOWN;
+        return result;
+    }
+
+    public void captureMob$convertTo$spawnReason(CreatureSpawnEvent.SpawnReason Mob$convertTo$spawnReason) {
+        this.Mob$convertTo$spawnReason = Mob$convertTo$spawnReason;
+    }
+
+    public CreatureSpawnEvent.SpawnReason getCaptureMob$convertTo$spawnReason() {
+        var result = this.Mob$convertTo$spawnReason;
+        this.Mob$convertTo$spawnReason = CreatureSpawnEvent.SpawnReason.DEFAULT;
+        return result;
+    }
+
+    public void capturePlayer$causeFoodExhaustion$reason(EntityExhaustionEvent.ExhaustionReason Player$causeFoodExhaustion$reason) {
+        this.Player$causeFoodExhaustion$reason = Player$causeFoodExhaustion$reason;
+    }
+
+    public EntityExhaustionEvent.ExhaustionReason getCapturePlayer$causeFoodExhaustion$reason() {
+        var result = this.Player$causeFoodExhaustion$reason;
+        this.Player$causeFoodExhaustion$reason = EntityExhaustionEvent.ExhaustionReason.UNKNOWN;
+        return result;
+    }
+
+    public void captureBrewingStandBlockEntity$doBrew$brewingStandBlockEntity(BrewingStandBlockEntity BrewingStandBlockEntity$doBrew$brewingStandBlockEntity) {
+        this.BrewingStandBlockEntity$doBrew$brewingStandBlockEntity = BrewingStandBlockEntity$doBrew$brewingStandBlockEntity;
+    }
+
+    public BrewingStandBlockEntity getCaptureBrewingStandBlockEntity$doBrew$brewingStandBlockEntity() {
+        var result = this.BrewingStandBlockEntity$doBrew$brewingStandBlockEntity;
+        this.BrewingStandBlockEntity$doBrew$brewingStandBlockEntity = null;
+        return result;
+    }
+
+    public void captureNaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason(CreatureSpawnEvent.SpawnReason NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason) {
+        this.NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason = NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason;
+    }
+
+    public CreatureSpawnEvent.SpawnReason getCaptureNaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason() {
+        var result = this.NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason;
+        this.NaturalSpawner$spawnCategoryForPosition$addFreshEntityWithPassengers$reason = CreatureSpawnEvent.SpawnReason.DEFAULT;
         return result;
     }
 }

--- a/src/main/java/org/bukkit/craftbukkit/v1_18_R2/event/CraftEventFactory.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_18_R2/event/CraftEventFactory.java
@@ -222,6 +222,8 @@ import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.potion.PotionEffect;
 
+import org.bukkit.event.entity.SpawnerSpawnEvent; // Spigot
+
 public class CraftEventFactory {
     public static final DamageSource MELTING = CraftDamageSource.copyOf(DamageSource.ON_FIRE);
     public static final DamageSource POISON = CraftDamageSource.copyOf(DamageSource.MAGIC);
@@ -1520,6 +1522,21 @@ public class CraftEventFactory {
         PrepareSmithingEvent event = new PrepareSmithingEvent(view, CraftItemStack.asCraftMirror(item).clone());
         event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
         event.getInventory().setItem(2, event.getResult());
+        return event;
+    }
+
+    /**
+     * Mob spawner event.
+     */
+    public static SpawnerSpawnEvent callSpawnerSpawnEvent(Entity spawnee, BlockPos pos) {
+        org.bukkit.craftbukkit.v1_18_R2.entity.CraftEntity entity = spawnee.getBukkitEntity();
+        BlockState state = entity.getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ()).getState();
+        if (!(state instanceof org.bukkit.block.CreatureSpawner)) {
+            state = null;
+        }
+
+        SpawnerSpawnEvent event = new SpawnerSpawnEvent(entity, (org.bukkit.block.CreatureSpawner) state);
+        entity.getServer().getPluginManager().callEvent(event);
         return event;
     }
 


### PR DESCRIPTION
修改一些小问题

**FoxServerLauncher#main**
```
        launchArgs = Arrays.cos = Arrays.copyOf(launchArgs, launchArgs.length + args.length);
        System.arraycopy(args, 0,pyOf(launchArgs, launchArgs.length + args.length);
        System.arraycopy(args, 0, launchArgs, launchArgs.length, args.length);
```
如果有自定义启动参数 会ArrayIndexOutOfBoundsException

**ShearsDispenseItemBehavior#tryShearLivingEntity**
在循环里ShearsDispenseItemBehavior.catserver$shearBukkitBlock.getAndSet(null)，下一轮循环读到的会是null
在if里ShearsDispenseItemBehavior.catserver$shearBukkitBlock.getAndSet(null)，如果没有进入if则catserver$shearBukkitBlock无法被重置
同时改用CatServerCaptures

**ServerLevel#tickPassenger**
bukkit加的p_8664_.postTick()处理生物通过地狱门时的传送，应该和p_8664_.rideTick()同时受forge加入的if(p_8664_.canUpdate())控制

**ServerGamePacketListenerImpl#onDisconnect**
cat注释掉的
`// this.server.getPlayerList().remove(this.player); // CatServer - fix dupe player logout`
但bukkit并没有留这一行
少了bukkit留下的`this.player.disconnect();`
看起来像是留错了诶（？）

**ServerHandshakePacketListenerImpl#handleIntention**
spigot的bug
这些翻译key被spigot换成String后应该是TextComponent（ChatMessage）
spigot1.20.1已修复

**Entity#changeDimension**
return前pop profiler

调用ServerLevel.makeObsidianPlatform时增加bukkit的this参数
`                  ServerLevel.makeObsidianPlatform(serverLevel, this);`

**ItemEntity#tick**
似乎把bukkit的patch放错位置了

bukkit:
```
             if (!this.level.isClientSide && this.age >= 6000) {
+                // CraftBukkit start - fire ItemDespawnEvent
+                if (org.bukkit.craftbukkit.event.CraftEventFactory.callItemDespawnEvent(this).isCancelled()) {
+                    this.age = 0;
+                    return;
+                }
+                // CraftBukkit end
                 this.discard();
             }
```

**LivingEntity#checkFallDamage**
forge的.setPos(p_20993_)

**LivingEntity#private void addEatEffect(ItemStack p_21064_, Level p_21065_, LivingEntity p_21066_)**
重置cause为默认值UNKNOWN

**LivingEntity#damageEntity0**
改为bukkit的写法 用damagesource.isDamageHelmet()

**LivingEntity#randomTeleport**
flag和flag1写反辣

forge
```
      boolean flag = false;
      BlockPos blockpos = BlockPos.containing(p_20985_, p_20986_, p_20987_);
      Level level = this.level();
      if (level.hasChunkAt(blockpos)) {
         boolean flag1 = false;

         if (flag1) {
            this.teleportTo(p_20985_, d3, p_20987_);
```
bukkit
```
        boolean flag1 = false;
        BlockPosition blockposition = BlockPosition.containing(d0, d1, d2);
        World world = this.level();
        if (world.hasChunkAt(blockposition)) {
            boolean flag2 = false;

             if (flag2) {
-                this.teleportTo(d0, d6, d2);
+                this.setPos(d3, d4, d5);
+                if (flag1) {
+                    if (!(this instanceof EntityPlayer)) {
```

cat
```
      boolean flag = false;
      BlockPos blockpos = new BlockPos(p_20985_, p_20986_, p_20987_);
      Level level = this.level;
      if (level.hasChunkAt(blockpos)) {
         boolean flag1 = false;

         if (flag) {
            var cause = CatServerCaptures.getCatServerCaptures().getCaptureTeleportCause();
            // CraftBukkit start - Teleport event
            // this.teleportTo(p_20985_, d3, p_20987_);

            this.setPos(d0, d1, d2);
            if (flag1) {
               if (!(this instanceof ServerPlayer)) {
```

**LivingEntity#heal**
`      this.resetRegainReason();`
保证不进if也能重置

**NaturalSpawner#spawnCategoryForPosition**
p_47040_.addFreshEntityWithPassengers(mob);用capture传入的reason在ServerLevelAccessor#addFreshEntityWithPassengers未被接收
同时修改ServerLevelAccessor

**Mob#convertTo**
确保catserver$spawnReason重置
同时改用CatServerCaptures

**ZombieVillager#tick**
bukkit的
```
         super.tick();
+        this.lastTick = MinecraftServer.currentTick; // CraftBukkit
     }
```

**net.minecraft.world.entity.player.Player#public void causeFoodExhaustion(float p_36400_)** this.catserver$causeFoodReason.getAndSet)在if里 如果没有进if的话catserver$causeFoodReason无法重置
同时改用CatServerCaptures

**ThrownPotion#applySplash**
bukkit的entity1

**Raid#tick**
似乎有一个bukkit的callRaidStopEvent的位置串了

**AbstractMinecart#setDragAir**
vanilla
`this.setDeltaMovement(this.getDeltaMovement().scale(0.95D));`
forge
`this.setDeltaMovement(this.getDeltaMovement().scale(getDragAir()));`
bukkit+cat
```
-            this.setDeltaMovement(this.getDeltaMovement().scale(0.95D));
+            // CraftBukkit start - replace magic numbers with our variables
+            this.setDeltaMovement(new Vec3D(this.getDeltaMovement().x * this.flyingX, this.getDeltaMovement().y * this.flyingY, this.getDeltaMovement().z * this.flyingZ));
+            // CraftBukkit end
```

这样的话 似乎forge的dragAir会失效
forge的xyz用同一个scale bukkit用3个 没法在保证各自正常功能的情况下用同一组scale来统一两边 所以用相乘的关系
`         this.setDeltaMovement(new Vec3(this.getDeltaMovement().x * this.flyingX, this.getDeltaMovement().y * this.flyingY, this.getDeltaMovement().z * this.flyingZ).scale(getDragAir()));`

**ChestMenu#getBukkitView**
bukkit
`      if (this.container instanceof PlayerInventory) {` -> net.minecraft.world.entity.player.PlayerInventory(official:net.minecraft.world.entity.player.Inventory)

cat
`      if (this.container instanceof PlayerInventory) {` -> org.bukkit.inventory.PlayerInventory

**EnchantmentMenu#slotsChanged**
j用forge的float类型
改用独立的数组循环索引k

**ArmorItem#dispenseArmor**
bukkit
```
    public static boolean dispenseArmor(ISourceBlock isourceblock, ItemStack itemstack) {

            ItemStack itemstack1 = itemstack.split(1);

            if (event.isCancelled()) {
                itemstack.grow(1);
                return false;
            }

            if (!event.getItem().equals(craftItem)) {
                itemstack.grow(1);
```

cat
```
         ItemStack itemstack = p_40400_.split(1);

         if (event.isCancelled()) {
            itemstack.grow(1);
            return false;
         }
         if (!event.getItem().equals(craftItem)) {
            itemstack.grow(1);
            // Chain to handler for new item
```

应该是p_40400_

**BaseSpawner/MobSpawnerAbstract#serverTick+CraftEventFactory#callSpawnerSpawnEvent**
补充spigot patch（这个在1.20.1转为craftbukkit patch）
spigot1182
BaseSpawner/MobSpawnerAbstract
```
                        // Spigot Start
                        if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, blockposition).isCancelled()) {
                            Entity vehicle = entity.getVehicle();
                            if (vehicle != null) {
                                vehicle.discard();
                            }
                            for (Entity passenger : entity.getIndirectPassengers()) {
                                passenger.discard();
                            }
                            continue;
                        }
                        // Spigot End
```

CraftEventFactory
```
    public static SpawnerSpawnEvent callSpawnerSpawnEvent(Entity spawnee, BlockPos pos) {
        org.bukkit.craftbukkit.v1_18_R2.entity.CraftEntity entity = spawnee.getBukkitEntity();
        BlockState state = entity.getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ()).getState();
        if (!(state instanceof org.bukkit.block.CreatureSpawner)) {
            state = null;
        }

        SpawnerSpawnEvent event = new SpawnerSpawnEvent(entity, (org.bukkit.block.CreatureSpawner) state);
        entity.getServer().getPluginManager().callEvent(event);
        return event;
    }
```

**BigDripleafBlock#private static void setTilt(BlockState p_152278_, Level p_152279_, BlockPos p_152280_, Tilt p_152281_)**
循环调用了 似乎应该调用下面那个
顺便加个强转

**CommandBlock#neighborChanged**
flag和flag1

bukkit
```
                boolean flag1 = world.hasNeighborSignal(blockposition);
                boolean flag2 = tileentitycommand.isPowered();
                // CraftBukkit start
                org.bukkit.block.Block bukkitBlock = world.getWorld().getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ());
                int old = flag2 ? 15 : 0;
                int current = flag1 ? 15 : 0;

                BlockRedstoneEvent eventRedstone = new BlockRedstoneEvent(bukkitBlock, old, current);
                world.getCraftServer().getPluginManager().callEvent(eventRedstone);
                flag1 = eventRedstone.getNewCurrent() > 0;
                // CraftBukkit end
```

cat
```
            boolean flag = p_51839_.hasNeighborSignal(p_51840_);
            boolean flag1 = commandblockentity.isPowered();
            // CraftBukkit start
            org.bukkit.block.Block bukkitBlock = p_51839_.getWorld().getBlockAt(p_51840_.getX(), p_51840_.getY(), p_51840_.getZ());
            int old = flag1 ? 15 : 0;
            int current = flag1 ? 15 : 0;
            BlockRedstoneEvent eventRedstone = new BlockRedstoneEvent(bukkitBlock, old, current);
            p_51839_.getCraftServer().getPluginManager().callEvent(eventRedstone);
            flag1 = eventRedstone.getNewCurrent() > 0;
            // CraftBukkit end
```

**AbstractFurnaceBlockEntity#getTotalCookTime**
bukkit的patch

**BeaconBlockEntity**
#applyEffect
#applyEffects
, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.BEACON);

**BeehiveBlockEntity**
#releaseOccupant
#releaseAllOccupants
确保重置catserver$isForceReleaseAllOccupants catserver$isForceReleaseOccupant

**BrewingStandBlockEntity#doBrew**
确保catserver$captureBrewBlockEntity重置
同时改用CatServerCaptures

实现// CatServer TODO: missing BrewEvent result

**HopperBlockEntity#ejectItems**
bukkit
`+                        ItemStack itemstack1 = addItem(iinventory, iinventory1, CraftItemStack.asNMSCopy(event.getItem()), `enumdirection);
cat
`                  ItemStack itemstack1 = addItem(p_155566_, p_155566_, CraftItemStack.asNMSCopy(event.getItem()), direction);`

iinventory是method传入的漏斗p_155566_
iinventory1是getAttachedContainer返回的目标tileentity

**HopperBlockEntity#private static boolean tryTakeInItemFromSlot(Hopper p_59355_, Container p_59356_, int p_59357_, Direction p_59358_)**
考虑mod里implements Hopper的其他BlockEntity/Entity

**FireBlock#updateShape**
bukkit
`+            if (!(generatoraccess instanceof World)) {` -> net.minecraft.world.level.Level
cat
`         if (!(p_53461_ instanceof World)) {` -> org.bukkit.World

**MushroomBlock#growMushroom**
bukkit1201+1182
`+        BlockSapling.treeType = (this == Blocks.BROWN_MUSHROOM) ? TreeType.BROWN_MUSHROOM : TreeType.BROWN_MUSHROOM; // CraftBukkit`
cat1182
`      SaplingBlock.treeType = (this == Blocks.BROWN_MUSHROOM) ? TreeType.BROWN_MUSHROOM : TreeType.BROWN_MUSHROOM; // CraftBukkit`
bukkit12110
`            BlockSapling.treeType = (this == Blocks.BROWN_MUSHROOM) ? TreeType.BROWN_MUSHROOM : TreeType.RED_MUSHROOM; // CraftBukkit`

bukkit的bug

**PistonBaseBlock#moveBlocks**
BlockPos和Direction

bukkit
```
    private boolean moveBlocks(World world, BlockPosition blockposition, EnumDirection enumdirection, boolean flag) {
        BlockPosition blockposition1 = blockposition.relative(enumdirection);

            EnumDirection enumdirection1 = flag ? enumdirection : enumdirection.getOpposite();

+            final org.bukkit.block.Block bblock = world.getWorld().getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ());

+                event = new BlockPistonExtendEvent(bblock, blocks, CraftBlock.notchToBlockFace(enumdirection1));
+            } else {
+                event = new BlockPistonRetractEvent(bblock, blocks, CraftBlock.notchToBlockFace(enumdirection1));
```

cat
```
   private boolean moveBlocks(Level p_60182_, BlockPos p_60183_, Direction p_60184_, boolean p_60185_) {
      BlockPos blockpos = p_60183_.relative(p_60184_);

         Direction direction = p_60185_ ? p_60184_ : p_60184_.getOpposite();

         final org.bukkit.block.Block bblock = p_60182_.getWorld().getBlockAt(blockpos.getX(), blockpos.getY(), blockpos.getZ());

            event = new BlockPistonExtendEvent(bblock, blocks, CraftBlock.notchToBlockFace(p_60184_));
         } else {
            event = new BlockPistonRetractEvent(bblock, blocks, CraftBlock.notchToBlockFace(p_60184_));
```

**RedStoneOreBlock#private static void interact(BlockState p_55493_, Level p_55494_, BlockPos p_55495_)**
setBlock保留if (!p_55493_.getValue(LIT))判断